### PR TITLE
docs: add automake note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You also need to install at least one node implementation to test. Ziggurat is c
 
 However, **please note that** **Docker is not supported** as it can theoretically produce unreliable test results and increases network complexity.
 
+**Note:** You will need to ensure that `automake` is installed when building from source e.g. `apt-get install automake`
+
 ```bash
 # After installing dependencies
 $ git clone https://github.com/zcash/zcash


### PR DESCRIPTION
This PR adds a note to install `automake` when building `zcashd` from source