### PR TITLE
doc: test results for new `zcashd` and `zebra` releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ node.initial_action(Action::WaitForConnection)
 
 Short overview of test cases and their current status. In case of failure, the behaviour observed for `zebra` and `zcashd` is usually documented in the test case.
 
-These results were obtained by running the test suite against [Zcashd v5.2.0](https://github.com/zcash/zcash/releases/tag/v5.2.0) (d6d2093) and [Zebra 1.0.0-beta.12](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-beta.12) (9e277ed).
+These results were obtained by running the test suite against [Zcashd v5.2.0](https://github.com/zcash/zcash/releases/tag/v5.2.0) (d6d2093) and [Zebra 1.0.0-beta.14](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-beta.14) (c3225331).
 
 | Legend |               |
 | :----: | ------------- |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ However, **please note that** **Docker is not supported** as it can theoreticall
 # After installing dependencies
 $ git clone https://github.com/zcash/zcash
 $ cd zcash
-$ git checkout v4.4.1            # optional, or use master
+$ git checkout v5.2.0            # optional, or use master
 $ ./zcutil/fetch-params.sh
 $ ./zcutil/build.sh -j$(nproc)   # or number of cores
 ```
@@ -119,7 +119,7 @@ node.initial_action(Action::WaitForConnection)
 
 Short overview of test cases and their current status. In case of failure, the behaviour observed for `zebra` and `zcashd` is usually documented in the test case.
 
-These results were obtained by running the test suite against [Zcashd v5.1.0](https://github.com/zcash/zcash/releases/tag/v5.1.0) (dda0f79) and [Zebra 1.0.0-beta.12](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-beta.12) (9e277ed).
+These results were obtained by running the test suite against [Zcashd v5.2.0](https://github.com/zcash/zcash/releases/tag/v5.2.0) (d6d2093) and [Zebra 1.0.0-beta.12](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-beta.12) (9e277ed).
 
 | Legend |               |
 | :----: | ------------- |


### PR DESCRIPTION
Updates the `README.md` with new results obtained from testing `zcashd v5.2.0` and `zebra v1.0.0-beta.14`. No major differences.