### PR TITLE
fix: make sure `TestMetrics` doesn't remove state

### DIFF
--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -200,10 +200,12 @@ async fn load_bearing() {
         let mut stats = Stats::new(MAX_PEERS, synth_count);
         stats.time = test_start.elapsed().as_secs_f64();
         {
-            stats.accepted = test_metrics.get_counter(METRIC_ACCEPTED) as u16;
-            stats.terminated = test_metrics.get_counter(METRIC_TERMINATED) as u16;
-            stats.rejected = test_metrics.get_counter(METRIC_REJECTED) as u16;
-            stats.conn_error = test_metrics.get_counter(METRIC_ERROR) as u16;
+            let snapshot = test_metrics.take_snapshot();
+
+            stats.accepted = test_metrics.get_counter(METRIC_ACCEPTED, &snapshot) as u16;
+            stats.terminated = test_metrics.get_counter(METRIC_TERMINATED, &snapshot) as u16;
+            stats.rejected = test_metrics.get_counter(METRIC_REJECTED, &snapshot) as u16;
+            stats.conn_error = test_metrics.get_counter(METRIC_ERROR, &snapshot) as u16;
 
             stats.timed_out = synth_count - stats.accepted - stats.rejected - stats.conn_error;
         }

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -202,10 +202,10 @@ async fn load_bearing() {
         {
             let snapshot = test_metrics.take_snapshot();
 
-            stats.accepted = test_metrics.get_counter(METRIC_ACCEPTED, &snapshot) as u16;
-            stats.terminated = test_metrics.get_counter(METRIC_TERMINATED, &snapshot) as u16;
-            stats.rejected = test_metrics.get_counter(METRIC_REJECTED, &snapshot) as u16;
-            stats.conn_error = test_metrics.get_counter(METRIC_ERROR, &snapshot) as u16;
+            stats.accepted = snapshot.get_counter(METRIC_ACCEPTED) as u16;
+            stats.terminated = snapshot.get_counter(METRIC_TERMINATED) as u16;
+            stats.rejected = snapshot.get_counter(METRIC_REJECTED) as u16;
+            stats.conn_error = snapshot.get_counter(METRIC_ERROR) as u16;
 
             stats.timed_out = synth_count - stats.accepted - stats.rejected - stats.conn_error;
         }

--- a/src/tests/performance/getdata_blocks.rs
+++ b/src/tests/performance/getdata_blocks.rs
@@ -157,7 +157,7 @@ async fn throughput() {
         let time_taken_secs = test_start.elapsed().as_secs_f64();
 
         let snapshot = test_metrics.take_snapshot();
-        if let Some(latencies) = test_metrics.construct_histogram(METRIC_LATENCY, &snapshot) {
+        if let Some(latencies) = snapshot.construct_histogram(METRIC_LATENCY) {
             if latencies.entries() >= 1 {
                 // add stats to table display
                 table.add_row(RequestStats::new(

--- a/src/tests/performance/getdata_blocks.rs
+++ b/src/tests/performance/getdata_blocks.rs
@@ -156,7 +156,8 @@ async fn throughput() {
 
         let time_taken_secs = test_start.elapsed().as_secs_f64();
 
-        if let Some(latencies) = test_metrics.construct_histogram(METRIC_LATENCY) {
+        let snapshot = test_metrics.take_snapshot();
+        if let Some(latencies) = test_metrics.construct_histogram(METRIC_LATENCY, &snapshot) {
             if latencies.entries() >= 1 {
                 // add stats to table display
                 table.add_row(RequestStats::new(

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -184,7 +184,8 @@ async fn throughput() {
 
         let time_taken_secs = test_start.elapsed().as_secs_f64();
 
-        if let Some(latencies) = test_metrics.construct_histogram(METRIC_LATENCY) {
+        let snapshot = test_metrics.take_snapshot();
+        if let Some(latencies) = test_metrics.construct_histogram(METRIC_LATENCY, &snapshot) {
             if latencies.entries() >= 1 {
                 // add stats to table display
                 table.add_row(RequestStats::new(

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -185,7 +185,7 @@ async fn throughput() {
         let time_taken_secs = test_start.elapsed().as_secs_f64();
 
         let snapshot = test_metrics.take_snapshot();
-        if let Some(latencies) = test_metrics.construct_histogram(METRIC_LATENCY, &snapshot) {
+        if let Some(latencies) = snapshot.construct_histogram(METRIC_LATENCY) {
             if latencies.entries() >= 1 {
                 // add stats to table display
                 table.add_row(RequestStats::new(

--- a/src/tests/resistance/stress_test.rs
+++ b/src/tests/resistance/stress_test.rs
@@ -299,9 +299,7 @@ async fn throughput() {
         let iteration_time = iteration_timer.elapsed().as_secs_f64();
 
         let snapshot = test_metrics.take_snapshot();
-        if let Some(request_latencies) =
-            test_metrics.construct_histogram(REQUEST_LATENCY, &snapshot)
-        {
+        if let Some(request_latencies) = snapshot.construct_histogram(REQUEST_LATENCY) {
             if request_latencies.entries() >= 1 {
                 let row = RequestStats::new(
                     peers as u16,
@@ -313,9 +311,7 @@ async fn throughput() {
             }
         }
 
-        if let Some(handshake_latencies) =
-            test_metrics.construct_histogram(HANDSHAKE_LATENCY, &snapshot)
-        {
+        if let Some(handshake_latencies) = snapshot.construct_histogram(HANDSHAKE_LATENCY) {
             if handshake_latencies.entries() >= 1 {
                 let row = RequestStats::new(peers as u16, 1, handshake_latencies, iteration_time);
                 handshake_table.add_row(row);
@@ -330,21 +326,16 @@ async fn throughput() {
                 ..Default::default()
             };
             {
-                stat.handshake_accepted =
-                    test_metrics.get_counter(HANDSHAKE_ACCEPTED, &snapshot) as u16;
-                stat.handshake_rejected =
-                    test_metrics.get_counter(HANDSHAKE_REJECTED, &snapshot) as u16;
+                stat.handshake_accepted = snapshot.get_counter(HANDSHAKE_ACCEPTED) as u16;
+                stat.handshake_rejected = snapshot.get_counter(HANDSHAKE_REJECTED) as u16;
 
-                stat.corrupt_terminated =
-                    test_metrics.get_counter(CORRUPT_TERMINATED, &snapshot) as u16;
-                stat.corrupt_ignored = test_metrics.get_counter(CORRUPT_IGNORED, &snapshot) as u16;
-                stat.corrupt_rejected =
-                    test_metrics.get_counter(CORRUPT_REJECTED, &snapshot) as u16;
-                stat.corrupt_reply = test_metrics.get_counter(CORRUPT_REPLY, &snapshot) as u16;
+                stat.corrupt_terminated = snapshot.get_counter(CORRUPT_TERMINATED) as u16;
+                stat.corrupt_ignored = snapshot.get_counter(CORRUPT_IGNORED) as u16;
+                stat.corrupt_rejected = snapshot.get_counter(CORRUPT_REJECTED) as u16;
+                stat.corrupt_reply = snapshot.get_counter(CORRUPT_REPLY) as u16;
 
-                stat.peers_dropped =
-                    test_metrics.get_counter(CONNECTION_TERMINATED, &snapshot) as u16;
-                stat.reply_errors = test_metrics.get_counter(BAD_REPLY, &snapshot) as u16;
+                stat.peers_dropped = snapshot.get_counter(CONNECTION_TERMINATED) as u16;
+                stat.reply_errors = snapshot.get_counter(BAD_REPLY) as u16;
             }
 
             stats.push(stat);

--- a/src/tools/metrics/recorder.rs
+++ b/src/tools/metrics/recorder.rs
@@ -57,19 +57,21 @@ impl Snapshot {
     }
 }
 
-pub fn initialize() -> Snapshotter {
-    let recorder = DebuggingRecorder::new();
-    let snapshotter = recorder.snapshotter();
-    let _ = recorder.install();
-
-    snapshotter
-}
-
 pub struct TestMetrics(Snapshotter);
+
+impl TestMetrics {
+    fn new() -> TestMetrics {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let _ = recorder.install();
+
+        TestMetrics(snapshotter)
+    }
+}
 
 impl Default for TestMetrics {
     fn default() -> Self {
-        Self(initialize())
+        Self::new()
     }
 }
 

--- a/src/tools/metrics/recorder.rs
+++ b/src/tools/metrics/recorder.rs
@@ -26,6 +26,9 @@ impl Default for TestMetrics {
 }
 
 impl TestMetrics {
+    // This is a false positive, `CompositeKey` does not depend on any interior mutable
+    // types for its hashing implementation. Therefore, it is safe to use in our context.
+    #[allow(clippy::mutable_key_type)]
     pub fn take_snapshot(&self) -> HashMap<CompositeKey, MetricVal> {
         let mut snapshot = HashMap::new();
 
@@ -43,6 +46,7 @@ impl TestMetrics {
         snapshot
     }
 
+    #[allow(clippy::mutable_key_type)]
     pub fn get_counter(
         &self,
         metric: &'static str,
@@ -56,6 +60,7 @@ impl TestMetrics {
         }
     }
 
+    #[allow(clippy::mutable_key_type)]
     pub fn get_gauge(
         &self,
         metric: &'static str,
@@ -69,6 +74,7 @@ impl TestMetrics {
         }
     }
 
+    #[allow(clippy::mutable_key_type)]
     pub fn get_histogram(
         &self,
         metric: &'static str,
@@ -82,6 +88,7 @@ impl TestMetrics {
         }
     }
 
+    #[allow(clippy::mutable_key_type)]
     pub fn construct_histogram(
         &self,
         metric: &'static str,


### PR DESCRIPTION
This PR fixes a number of issues with our current `DebuggingRecorder` implementation. We now take a snapshot separately from querying the values. This fixes an issue in `resistance::stress_test` where we had two sequential `construct_histogram` queries; the initial one would erase state after its use, leading to nil data in our subsequent query. Now that state is handled separately, we also get a minor boost to performance.
