### PR TITLE
Adhere to new test naming convention

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -18,6 +18,8 @@ For load testing, "reasonable load" and "heavy load" will need to be defined.
 
 The tests can be run with `cargo test` once Ziggurat is properly configured and dependencies (node instance to be tested) are satisfied. See the [README](README.md) for details.
 
+Tests are grouped into the following categories: conformance, performance, and resistance. Each test is named after the category it belongs to, in addition to what's being tested. For example, `c001_handshake_when_node_receives_connection` is the first conformance test and tests the handshake behavior on the receiving end. The full name convention is: `id_part_t(subtest_no)_(message type)_(extra_test_desc)`.
+
 # Types of Tests
 
 ## Conformance
@@ -242,7 +244,6 @@ The test index makes use of symbolic language in describing connection and messa
 
     The node disconnects for trivial (non-fuzz, non-malicious) cases.
 
-    - `Ping` timeout.
     - `Pong` with wrong nonce.
     - `GetData` with mixed types in inventory list.
     - `Inv` with mixed types in inventory list.

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,7 +18,7 @@ For load testing, "reasonable load" and "heavy load" will need to be defined.
 
 The tests can be run with `cargo test` once Ziggurat is properly configured and dependencies (node instance to be tested) are satisfied. See the [README](README.md) for details.
 
-Tests are grouped into the following categories: conformance, performance, and resistance. Each test is named after the category it belongs to, in addition to what's being tested. For example, `c001_handshake_when_node_receives_connection` is the first conformance test and tests the handshake behavior on the receiving end. The full name convention is: `id_part_t(subtest_no)_(message type)_(extra_test_desc)`.
+Tests are grouped into the following categories: conformance, performance, and resistance. Each test is named after the category it belongs to, in addition to what's being tested. For example, `c001_handshake_when_node_receives_connection` is the first conformance test and tests the handshake behavior on the receiving end. The full naming convention is: `id_part_t(subtest_no)_(message type)_(extra_test_desc)`.
 
 # Types of Tests
 

--- a/src/tests/conformance/handshake/complete_handshake.rs
+++ b/src/tests/conformance/handshake/complete_handshake.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn when_node_receives_connection() {
+async fn c001_handshake_when_node_receives_connection() {
     // ZG-CONFORMANCE-001
 
     // Spin up a node instance.
@@ -34,7 +34,7 @@ async fn when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn when_node_initiates_connection() {
+async fn c002_handshake_when_node_initiates_connection() {
     // ZG-CONFORMANCE-002
 
     // Create a synthetic node and enable handshaking.

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
@@ -22,21 +22,24 @@ mod when_node_receives_connection {
     use super::*;
 
     #[tokio::test]
-    async fn get_addr() {
+    #[allow(non_snake_case)]
+    async fn c005_t1_GET_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetAddr).await.unwrap();
     }
 
     #[tokio::test]
-    async fn mempool() {
+    #[allow(non_snake_case)]
+    async fn c005_t2_MEMPOOL() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
-    async fn ping() {
+    #[allow(non_snake_case)]
+    async fn c005_t3_PING() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
@@ -45,7 +48,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn pong() {
+    #[allow(non_snake_case)]
+    async fn c005_t4_PONG() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Pong(Nonce::default()))
@@ -54,14 +58,16 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn addr() {
+    #[allow(non_snake_case)]
+    async fn c005_t5_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Addr(Addr::empty())).await.unwrap();
     }
 
     #[tokio::test]
-    async fn get_headers() {
+    #[allow(non_snake_case)]
+    async fn c005_t6_GET_HEADERS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -70,7 +76,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn get_blocks() {
+    #[allow(non_snake_case)]
+    async fn c005_t7_GET_BLOCKS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -79,7 +86,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn get_data_block() {
+    #[allow(non_snake_case)]
+    async fn c005_t8_GET_DATA_BLOCK() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -87,7 +95,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn get_data_tx() {
+    #[allow(non_snake_case)]
+    async fn c005_t9_GET_DATA_TX() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetData(Inv::new(vec![Block::testnet_genesis()
@@ -98,7 +107,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn inv() {
+    #[allow(non_snake_case)]
+    async fn c005_t10_INV() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -106,7 +116,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn not_found() {
+    #[allow(non_snake_case)]
+    async fn c005_t11_NOT_FOUND() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -162,21 +173,24 @@ mod when_node_initiates_connection {
     use super::*;
 
     #[tokio::test]
-    async fn get_addr() {
+    #[allow(non_snake_case)]
+    async fn c006_t1_GET_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetAddr).await.unwrap();
     }
 
     #[tokio::test]
-    async fn mempool() {
+    #[allow(non_snake_case)]
+    async fn c006_t2_MEMPOOL() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
-    async fn ping() {
+    #[allow(non_snake_case)]
+    async fn c006_t3_PING() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
@@ -185,7 +199,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn pong() {
+    #[allow(non_snake_case)]
+    async fn c006_t4_PONG() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Pong(Nonce::default()))
@@ -194,14 +209,16 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn addr() {
+    #[allow(non_snake_case)]
+    async fn c006_t5_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Addr(Addr::empty())).await.unwrap();
     }
 
     #[tokio::test]
-    async fn get_headers() {
+    #[allow(non_snake_case)]
+    async fn c006_t6_GET_HEADERS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -210,7 +227,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn get_blocks() {
+    #[allow(non_snake_case)]
+    async fn c006_t7_GET_BLOCKS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -219,7 +237,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn get_data_block() {
+    #[allow(non_snake_case)]
+    async fn c006_t8_GET_DATA_BLOCK() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -227,7 +246,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn get_data_tx() {
+    #[allow(non_snake_case)]
+    async fn c006_t9_GET_DATA_TX() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetData(Inv::new(vec![Block::testnet_genesis()
@@ -238,7 +258,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn inv() {
+    #[allow(non_snake_case)]
+    async fn c006_t10_INV() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -246,7 +267,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn not_found() {
+    #[allow(non_snake_case)]
+    async fn c006_t11_NOT_FOUND() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
@@ -22,28 +22,32 @@ mod when_node_receives_connection {
     use super::*;
 
     #[tokio::test]
-    async fn get_addr() {
+    #[allow(non_snake_case)]
+    async fn c003_t1_GET_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetAddr).await.unwrap();
     }
 
     #[tokio::test]
-    async fn mempool() {
+    #[allow(non_snake_case)]
+    async fn c003_t2_MEMPOOL() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
-    async fn verack() {
+    #[allow(non_snake_case)]
+    async fn c003_t3_VERACK() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Verack).await.unwrap();
     }
 
     #[tokio::test]
-    async fn ping() {
+    #[allow(non_snake_case)]
+    async fn c003_t4_PING() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
@@ -52,7 +56,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn pong() {
+    #[allow(non_snake_case)]
+    async fn c003_t5_PONG() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Pong(Nonce::default()))
@@ -61,14 +66,16 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn addr() {
+    #[allow(non_snake_case)]
+    async fn c003_t6_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Addr(Addr::empty())).await.unwrap();
     }
 
     #[tokio::test]
-    async fn get_headers() {
+    #[allow(non_snake_case)]
+    async fn c003_t7_GET_HEADERS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -77,7 +84,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn get_blocks() {
+    #[allow(non_snake_case)]
+    async fn c003_t8_GET_BLOCKS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -86,7 +94,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn get_data_block() {
+    #[allow(non_snake_case)]
+    async fn c003_t9_GET_DATA_BLOCK() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -94,7 +103,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn get_data_tx() {
+    #[allow(non_snake_case)]
+    async fn c003_t10_GET_DATA_TX() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetData(Inv::new(vec![Block::testnet_genesis()
@@ -105,7 +115,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn inv() {
+    #[allow(non_snake_case)]
+    async fn c003_t11_INV() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -113,7 +124,8 @@ mod when_node_receives_connection {
     }
 
     #[tokio::test]
-    async fn not_found() {
+    #[allow(non_snake_case)]
+    async fn c003_t12_NOT_FOUND() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -192,28 +204,32 @@ mod when_node_initiates_connection {
     use super::*;
 
     #[tokio::test]
-    async fn get_addr() {
+    #[allow(non_snake_case)]
+    async fn c004_t1_GET_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetAddr).await.unwrap();
     }
 
     #[tokio::test]
-    async fn mempool() {
+    #[allow(non_snake_case)]
+    async fn c004_t2_MEMPOOL() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
-    async fn verack() {
+    #[allow(non_snake_case)]
+    async fn c004_t3_VERACK() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Verack).await.unwrap();
     }
 
     #[tokio::test]
-    async fn ping() {
+    #[allow(non_snake_case)]
+    async fn c004_t4_PING() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
@@ -222,7 +238,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn pong() {
+    #[allow(non_snake_case)]
+    async fn c004_t5_PONG() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Pong(Nonce::default()))
@@ -231,14 +248,16 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn addr() {
+    #[allow(non_snake_case)]
+    async fn c004_t6_ADDR() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::Addr(Addr::empty())).await.unwrap();
     }
 
     #[tokio::test]
-    async fn get_headers() {
+    #[allow(non_snake_case)]
+    async fn c004_t7_GET_HEADERS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -247,7 +266,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn get_blocks() {
+    #[allow(non_snake_case)]
+    async fn c004_t8_GET_BLOCKS() {
         // zcashd: pass
         // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
@@ -256,7 +276,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn get_data_block() {
+    #[allow(non_snake_case)]
+    async fn c004_t9_GET_DATA_BLOCK() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -264,7 +285,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn get_data_tx() {
+    #[allow(non_snake_case)]
+    async fn c004_t10_GET_DATA_TX() {
         // zcashd: pass
         // zebra:  pass
         run_test_case(Message::GetData(Inv::new(vec![Block::testnet_genesis()
@@ -275,7 +297,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn inv() {
+    #[allow(non_snake_case)]
+    async fn c004_t11_INV() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
@@ -283,7 +306,8 @@ mod when_node_initiates_connection {
     }
 
     #[tokio::test]
-    async fn not_found() {
+    #[allow(non_snake_case)]
+    async fn c004_t12_NOT_FOUND() {
         // zcashd: pass
         // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);

--- a/src/tests/conformance/handshake/reject_version.rs
+++ b/src/tests/conformance/handshake/reject_version.rs
@@ -11,7 +11,8 @@ use crate::{
 };
 
 #[tokio::test]
-async fn reusing_nonce() {
+#[allow(non_snake_case)]
+async fn c007_PING_reusing_nonce() {
     // ZG-CONFORMANCE-007
     //
     // The node rejects connections reusing its nonce (usually indicative of self-connection).
@@ -52,7 +53,8 @@ async fn reusing_nonce() {
 }
 
 #[tokio::test]
-async fn with_obsolete_version_numbers() {
+#[allow(non_snake_case)]
+async fn c008_VERSION_with_obsolete_number() {
     // ZG-CONFORMANCE-008
     //
     // The node rejects connections with obsolete node versions.

--- a/src/tests/conformance/invalid_message/disconnect.rs
+++ b/src/tests/conformance/invalid_message/disconnect.rs
@@ -37,7 +37,8 @@ use crate::{
 };
 
 #[tokio::test]
-async fn pong_with_wrong_nonce() {
+#[allow(non_snake_case)]
+async fn c012_t1_PONG_with_wrong_nonce() {
     // zcashd: fail (message ignored)
     // zebra:  fail (message ignored)
 
@@ -88,7 +89,8 @@ async fn pong_with_wrong_nonce() {
 }
 
 #[tokio::test]
-async fn get_data_with_mixed_types() {
+#[allow(non_snake_case)]
+async fn c012_t2_GET_DATA_with_mixed_types() {
     // zcashd: fail (replies with Block)
     // zebra:  fail (replies with NotFound)
     let genesis_block = Block::testnet_genesis();
@@ -98,7 +100,8 @@ async fn get_data_with_mixed_types() {
 }
 
 #[tokio::test]
-async fn inv_with_mixed_types() {
+#[allow(non_snake_case)]
+async fn c012_t3_INV_with_mixed_types() {
     // zcashd: fail (message ignored)
     // zebra:  fail (message ignored)
 
@@ -111,7 +114,8 @@ async fn inv_with_mixed_types() {
 }
 
 #[tokio::test]
-async fn addr_without_timestamp() {
+#[allow(non_snake_case)]
+async fn c012_t4_ADDR_without_timestamp() {
     // zcashd: fail (replies with Reject(Malformed))
     // zebra:  pass
 

--- a/src/tests/conformance/invalid_message/reject.rs
+++ b/src/tests/conformance/invalid_message/reject.rs
@@ -25,7 +25,8 @@ use crate::{
 };
 
 #[tokio::test]
-async fn version_post_handshake() {
+#[allow(non_snake_case)]
+async fn c009_t1_VERSION_post_handshake() {
     // zcashd: pass
     // zebra:  fail (connection terminated)
     let version = Message::Version(Version::new(
@@ -37,7 +38,8 @@ async fn version_post_handshake() {
 }
 
 #[tokio::test]
-async fn verack_post_handshake() {
+#[allow(non_snake_case)]
+async fn c009_t2_VERACK_post_handshake() {
     // zcashd: fail (ignored)
     // zebra:  fail (connection terminated)
     run_test_case(Message::Verack, CCode::Duplicate)
@@ -46,7 +48,8 @@ async fn verack_post_handshake() {
 }
 
 #[tokio::test]
-async fn mixed_inventory() {
+#[allow(non_snake_case)]
+async fn c009_t3_INV_mixed_inventory() {
     // TODO: is this the desired behaviour, https://github.com/ZcashFoundation/zebra/issues/2107
     // might suggest it is.
     // zcashd: fail (ignored)
@@ -60,7 +63,8 @@ async fn mixed_inventory() {
 }
 
 #[tokio::test]
-async fn multi_block_inventory() {
+#[allow(non_snake_case)]
+async fn c009_t4_INV_multi_block_inventory() {
     // zcashd: fail (ignored)
     // zebra:  fail (ignored)
     let multi_block_inv = vec![
@@ -75,7 +79,8 @@ async fn multi_block_inventory() {
 }
 
 #[tokio::test]
-async fn bloom_filter_add() {
+#[allow(non_snake_case)]
+async fn c009_t5_BLOOM_FILTER_ADD() {
     // zcashd: fail (ccode: Malformed)
     // zebra:  fail (ignored)
     run_test_case(Message::FilterAdd(FilterAdd::default()), CCode::Obsolete)
@@ -84,7 +89,8 @@ async fn bloom_filter_add() {
 }
 
 #[tokio::test]
-async fn bloom_filter_load() {
+#[allow(non_snake_case)]
+async fn c009_t6_BLOOM_FILTER_LOAD() {
     // zcashd: fail (ccode: Malformed)
     // zebra:  fail (ignored)
     run_test_case(Message::FilterLoad(FilterLoad::default()), CCode::Obsolete)
@@ -93,7 +99,8 @@ async fn bloom_filter_load() {
 }
 
 #[tokio::test]
-async fn bloom_filter_clear() {
+#[allow(non_snake_case)]
+async fn c009_t7_BLOOM_FILTER_CLEAR() {
     // zcashd: fail (ignored)
     // zebra:  fail (ignored)
     run_test_case(Message::FilterClear, CCode::Obsolete)

--- a/src/tests/conformance/peering.rs
+++ b/src/tests/conformance/peering.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn eagerly_crawls_network_for_peers() {
+async fn c013_eagerly_crawls_network_for_peers() {
     // ZG-CONFORMANCE-013
     //
     // The node crawls the network for new peers and eagerly connects.
@@ -102,7 +102,7 @@ async fn eagerly_crawls_network_for_peers() {
 }
 
 #[tokio::test]
-async fn correctly_lists_peers() {
+async fn c014_correctly_lists_peers() {
     // ZG-CONFORMANCE-014
     //
     // The node responds to a `GetAddr` with a list of peers it’s connected to. This command

--- a/src/tests/conformance/query/basic_query.rs
+++ b/src/tests/conformance/query/basic_query.rs
@@ -40,7 +40,8 @@ mod node_is_seeded_with_blocks {
     use super::*;
 
     #[tokio::test]
-    async fn ping() {
+    #[allow(non_snake_case)]
+    async fn c011_t1_PING() {
         // zcashd: pass
         // zebra:  fail (seeding not supported for zebra)
         let nonce = Nonce::default();
@@ -50,7 +51,8 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_addr() {
+    #[allow(non_snake_case)]
+    async fn c011_t2_GET_ADDR() {
         // zcashd: fail (query ignored)
         // zebra:  fail (seeding not supported for zebra)
         let reply = run_test_case(Message::GetAddr).await.unwrap();
@@ -58,7 +60,8 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn mempool() {
+    #[allow(non_snake_case)]
+    async fn c011_t3_MEMPOOL() {
         // zcashd: fail (query ignored)
         // zebra:  fail (seeding not supported for zebra)
         let reply = run_test_case(Message::MemPool).await.unwrap();
@@ -66,7 +69,8 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_blocks() {
+    #[allow(non_snake_case)]
+    async fn c011_t4_GET_BLOCKS() {
         // zcashd: pass
         // zebra:  fail (seeding not supported for zebra)
         let query = Message::GetBlocks(LocatorHashes::new(
@@ -78,7 +82,8 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_data_block() {
+    #[allow(non_snake_case)]
+    async fn c011_t5_GET_DATA_BLOCK() {
         // zcashd: pass
         // zebra:  fail (seeding not supported for zebra)
         let query = Message::GetData(Inv::new(vec![Block::testnet_2().inv_hash()]));
@@ -87,8 +92,9 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
+    #[allow(non_snake_case)]
     // This test should currently fail, since we have no way of seeding the Mempool of the node.
-    async fn get_data_tx() {
+    async fn c011_t6_GET_DATA_TX() {
         // zcashd: fail (NotFound), this is expected as we cannot seed the mempool of the node.
         // zebra:  fail (seeding not supported for zebra)
         let query = Message::GetData(Inv::new(vec![Block::testnet_genesis().txs[0].inv_hash()]));
@@ -97,7 +103,8 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_headers() {
+    #[allow(non_snake_case)]
+    async fn c011_t7_GET_HEADERS() {
         // zcashd: pass
         // zebra:  fail (seeding not supported for zebra)
         let query = Message::GetHeaders(LocatorHashes::new(
@@ -150,7 +157,8 @@ mod node_is_not_seeded_with_blocks {
     use super::*;
 
     #[tokio::test]
-    async fn ping() {
+    #[allow(non_snake_case)]
+    async fn c011_t8_PING() {
         // zcashd: pass
         // zebra:  pass
         let nonce = Nonce::default();
@@ -160,7 +168,8 @@ mod node_is_not_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_addr() {
+    #[allow(non_snake_case)]
+    async fn c011_t9_GET_ADDR() {
         // zcashd: fail (query ignored)
         // zebra:  fail (query ignored, nil response internally)
         let reply = run_test_case(Message::GetAddr).await.unwrap();
@@ -168,7 +177,8 @@ mod node_is_not_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn mempool() {
+    #[allow(non_snake_case)]
+    async fn c011_t10_MEMPOOL() {
         // zcashd: fail (query ignored)
         // zebra:  fail (query ignored)
         let reply = run_test_case(Message::MemPool).await.unwrap();
@@ -176,7 +186,8 @@ mod node_is_not_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_blocks() {
+    #[allow(non_snake_case)]
+    async fn c011_t11_GET_BLOCKS() {
         // zcashd: fail (query ignored)
         // zebra:  fail (query ignored)
         let query = Message::GetBlocks(LocatorHashes::new(
@@ -188,7 +199,8 @@ mod node_is_not_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_data_block() {
+    #[allow(non_snake_case)]
+    async fn c011_t12_GET_DATA_BLOCK() {
         // zcashd: fail (query ignored)
         // zebra:  fail (query ignored), pass when timeout is used to account for node startup (10s
         // is usually enough).
@@ -200,7 +212,8 @@ mod node_is_not_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_data_tx() {
+    #[allow(non_snake_case)]
+    async fn c011_t13_GET_DATA_TX() {
         // zcashd: pass
         // zebra:  fail (query ignored), sometimes pass (flaky), reliably passes when timeout is
         // used to account for node startup (10s is usually enough).
@@ -212,7 +225,8 @@ mod node_is_not_seeded_with_blocks {
     }
 
     #[tokio::test]
-    async fn get_headers() {
+    #[allow(non_snake_case)]
+    async fn c011_t14_GET_HEADERS() {
         // zcashd: pass
         // zebra:  fail (query ignored)
         let query = Message::GetHeaders(LocatorHashes::new(

--- a/src/tests/conformance/query/get_blocks.rs
+++ b/src/tests/conformance/query/get_blocks.rs
@@ -86,7 +86,8 @@ mod stop_hash_is_zero {
     use super::*;
 
     #[tokio::test]
-    async fn from_block_0_onwards() {
+    #[allow(non_snake_case)]
+    async fn c016_t1_GET_BLOCKS_block_0_onwards() {
         // zcashd: pass
         let index = 0;
         let response = run_test_case(GetBlocks::from_indices(index, None))
@@ -97,7 +98,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn from_block_1_onwards() {
+    #[allow(non_snake_case)]
+    async fn c016_t2_GET_BLOCKS_from_block_1_onwards() {
         // zcashd: pass
         let index = 1;
         let response = run_test_case(GetBlocks::from_indices(index, None))
@@ -108,7 +110,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn from_block_5_onwards() {
+    #[allow(non_snake_case)]
+    async fn c016_t3_GET_BLOCKS_from_block_5_onwards() {
         // zcashd: pass
         let index = 5;
         let response = run_test_case(GetBlocks::from_indices(index, None))
@@ -119,7 +122,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn from_penultimate_block_onwards() {
+    #[allow(non_snake_case)]
+    async fn c016_t4_GET_BLOCKS_from_penultimate_block_onwards() {
         // zcashd: pass
         let index = SEED_BLOCKS.len() - 2;
         let response = run_test_case(GetBlocks::from_indices(index, None))
@@ -130,7 +134,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn final_block_is_ignored() {
+    #[allow(non_snake_case)]
+    async fn c016_t5_GET_BLOCKS_final_block_is_ignored() {
         // Test that we get no response for the final block in the known-chain
         // (this is the behaviour exhibited by zcashd - a more well-formed response
         // might be sending an empty inventory instead).
@@ -145,7 +150,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn out_of_order() {
+    #[allow(non_snake_case)]
+    async fn c016_t6_GET_BLOCKS_out_of_order() {
         // Node expects the block hashes in reverse order, i.e. newest first.
         // It should latch onto the first known hash and ignore the rest.
         // In this test we swop the hash order and expect it to ignore the
@@ -167,7 +173,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn off_chain_correction() {
+    #[allow(non_snake_case)]
+    async fn c016_t7_GET_BLOCKS_off_chain_correction() {
         // Test that we get corrected if we are "off chain".
         // We expect that unknown hashes get ignored, until it finds a known hash; it then returns
         // all known children of that block.
@@ -193,7 +200,8 @@ mod stop_hash_is_start_hash {
     use super::*;
 
     #[tokio::test]
-    async fn from_block_0_to_0() {
+    #[allow(non_snake_case)]
+    async fn c016_t8_GET_BLOCKS_from_block_0_to_0() {
         // zcashd: fail (sends all blocks[1+] - same behaviour as if query was not range limited)
         let index = 0;
         let response = run_test_case(GetBlocks::from_indices(index, Some(index)))
@@ -204,7 +212,8 @@ mod stop_hash_is_start_hash {
     }
 
     #[tokio::test]
-    async fn from_block_4_to_4() {
+    #[allow(non_snake_case)]
+    async fn c016_t9_GET_BLOCKS_from_block_4_to_4() {
         // zcashd: fail (sends all blocks[5+] - same behaviour as if query was not range limited)
         let index = 4;
         let response = run_test_case(GetBlocks::from_indices(index, Some(index)))
@@ -215,7 +224,8 @@ mod stop_hash_is_start_hash {
     }
 
     #[tokio::test]
-    async fn from_final_block_to_final_block() {
+    #[allow(non_snake_case)]
+    async fn c016_t10_GET_BLOCKS_from_final_block_to_final_block() {
         // zcashd: pass
         let index = SEED_BLOCKS.len() - 1;
         let response = run_test_case(GetBlocks::from_indices(index, Some(index)))
@@ -230,7 +240,8 @@ mod ranged {
     use super::*;
 
     #[tokio::test]
-    async fn from_block_0_to_1() {
+    #[allow(non_snake_case)]
+    async fn c016_t11_GET_BLOCKS_from_block_0_to_1() {
         // zcashd: pass
         let response = run_test_case(GetBlocks::from_indices(0, Some(1)))
             .await
@@ -240,7 +251,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_block_0_to_5() {
+    #[allow(non_snake_case)]
+    async fn c016_t12_GET_BLOCKS_from_block_0_to_5() {
         // zcashd: pass
         let range = (0, 5);
         let response = run_test_case(GetBlocks::from_indices(range.0, Some(range.1)))
@@ -251,7 +263,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_block_0_to_final_block() {
+    #[allow(non_snake_case)]
+    async fn c016_t13_GET_BLOCKS_from_block_0_to_final_block() {
         // zcashd: pass
         let range = (0, SEED_BLOCKS.len() - 1);
         let response = run_test_case(GetBlocks::from_indices(range.0, Some(range.1)))
@@ -262,7 +275,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_block_3_to_9() {
+    #[allow(non_snake_case)]
+    async fn c016_t14_GET_BLOCKS_from_block_3_to_9() {
         // zcashd: pass
         let range = (3, 9);
         let response = run_test_case(GetBlocks::from_indices(range.0, Some(range.1)))
@@ -273,7 +287,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_penultimate_block_to_final_block() {
+    #[allow(non_snake_case)]
+    async fn c016_t15_GET_BLOCKS_from_penultimate_block_to_final_block() {
         // zcashd: pass
         let range = (SEED_BLOCKS.len() - 2, SEED_BLOCKS.len() - 1);
         let response = run_test_case(GetBlocks::from_indices(range.0, Some(range.1)))
@@ -284,7 +299,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn off_chain_correction() {
+    #[allow(non_snake_case)]
+    async fn c016_t16_GET_BLOCKS_off_chain_correction() {
         // Test that we get corrected if we are "off chain".
         // We expect that unknown hashes get ignored, until it finds a known hash; it then returns
         // all known children of that block.
@@ -305,7 +321,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn stop_hash_off_chain() {
+    #[allow(non_snake_case)]
+    async fn c016_t17_GET_BLOCKS_stop_hash_off_chain() {
         // Sends a query for all blocks starting from [3], but with
         // a stop_hash that does not match any block on the chain.
         // We expect the node to send all blocks from [3] onwards since the

--- a/src/tests/conformance/query/get_data.rs
+++ b/src/tests/conformance/query/get_data.rs
@@ -21,7 +21,8 @@ mod single_block {
     use super::*;
 
     #[tokio::test]
-    async fn block_last() {
+    #[allow(non_snake_case)]
+    async fn c018_t1_GET_DATA_block_last() {
         // zcashd: pass
         let block = SEED_BLOCKS.last().unwrap().clone();
         let query = Message::GetData(Inv::new(vec![block.inv_hash()]));
@@ -31,7 +32,8 @@ mod single_block {
     }
 
     #[tokio::test]
-    async fn block_first() {
+    #[allow(non_snake_case)]
+    async fn c018_t2_GET_DATA_block_first() {
         // zcashd: pass
         let block = SEED_BLOCKS.first().unwrap().clone();
         let query = Message::GetData(Inv::new(vec![block.inv_hash()]));
@@ -41,7 +43,8 @@ mod single_block {
     }
 
     #[tokio::test]
-    async fn block_5() {
+    #[allow(non_snake_case)]
+    async fn c018_t3_GET_DATA_block_5() {
         // zcashd: pass
         let block = SEED_BLOCKS[5].clone();
         let query = Message::GetData(Inv::new(vec![block.inv_hash()]));
@@ -51,7 +54,8 @@ mod single_block {
     }
 
     #[tokio::test]
-    async fn non_existent() {
+    #[allow(non_snake_case)]
+    async fn c018_t4_GET_DATA_non_existent() {
         // zcashd: fail (ignores non-existent block)
         let inv = Inv::new(vec![InvHash::new(ObjectKind::Block, Hash::new([17; 32]))]);
         let query = Message::GetData(inv.clone());
@@ -65,7 +69,8 @@ mod multiple_blocks {
     use super::*;
 
     #[tokio::test]
-    async fn all() {
+    #[allow(non_snake_case)]
+    async fn c018_t5_GET_DATA_all() {
         // zcashd: pass
         let blocks = &SEED_BLOCKS;
         let inv_hash = blocks.iter().map(|block| block.inv_hash()).collect();
@@ -79,7 +84,8 @@ mod multiple_blocks {
     }
 
     #[tokio::test]
-    async fn out_of_order() {
+    #[allow(non_snake_case)]
+    async fn c018_t6_GET_DATA_out_of_order() {
         // zcashd: pass
         let blocks = vec![&SEED_BLOCKS[3], &SEED_BLOCKS[1], &SEED_BLOCKS[7]];
         let inv_hash = blocks.iter().map(|block| block.inv_hash()).collect();
@@ -93,7 +99,8 @@ mod multiple_blocks {
     }
 
     #[tokio::test]
-    async fn blocks_1_to_8() {
+    #[allow(non_snake_case)]
+    async fn c018_t7_GET_DATA_blocks_1_to_8() {
         // zcashd: pass
         let blocks = &SEED_BLOCKS[1..=8];
         let inv_hash = blocks.iter().map(|block| block.inv_hash()).collect();
@@ -107,7 +114,8 @@ mod multiple_blocks {
     }
 
     #[tokio::test]
-    async fn non_existent_blocks() {
+    #[allow(non_snake_case)]
+    async fn c018_t8_GET_DATA_non_existent_blocks() {
         // zcashd: fails (ignores non-existent blocks).
         let inv = Inv::new(vec![
             InvHash::new(ObjectKind::Block, Hash::new([17; 32])),
@@ -122,7 +130,8 @@ mod multiple_blocks {
     }
 
     #[tokio::test]
-    async fn mixed_existent_and_non_existent_blocks() {
+    #[allow(non_snake_case)]
+    async fn c018_t9_GET_DATA_mixed_existent_and_non_existent_blocks() {
         // Test a mixture of existent and non-existent blocks
         // interwoven together.
         //

--- a/src/tests/conformance/query/get_headers.rs
+++ b/src/tests/conformance/query/get_headers.rs
@@ -85,7 +85,8 @@ mod stop_hash_is_zero {
     use super::*;
 
     #[tokio::test]
-    async fn from_block_0_onwards() {
+    #[allow(non_snake_case)]
+    async fn c017_t1_GET_HEADERS_from_block_0_onwards() {
         // zcashd: pass
         let index = 0;
         let response = run_test_case(GetHeaders::from_indices(index, None))
@@ -96,7 +97,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn from_block_1_onwards() {
+    #[allow(non_snake_case)]
+    async fn c017_t2_GET_HEADERS_from_block_1_onwards() {
         // zcashd: pass
         let index = 1;
         let response = run_test_case(GetHeaders::from_indices(index, None))
@@ -107,7 +109,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn from_block_5_onwards() {
+    #[allow(non_snake_case)]
+    async fn c017_t3_GET_HEADERS_from_block_5_onwards() {
         // zcashd: pass
         let index = 5;
         let response = run_test_case(GetHeaders::from_indices(index, None))
@@ -118,7 +121,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn from_penultimate_block_onwards() {
+    #[allow(non_snake_case)]
+    async fn c017_t4_GET_HEADERS_from_penultimate_block_onwards() {
         // zcashd: pass
         let index = SEED_BLOCKS.len() - 2;
         let response = run_test_case(GetHeaders::from_indices(index, None))
@@ -129,7 +133,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn final_block() {
+    #[allow(non_snake_case)]
+    async fn c017_t5_GET_HEADERS_final_block() {
         // We expect an empty Headers list.
         //
         // zcashd: pass
@@ -142,7 +147,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn out_of_order() {
+    #[allow(non_snake_case)]
+    async fn c017_t6_GET_HEADERS_out_of_order() {
         // Node expects the block hashes in reverse order, i.e. newest first.
         // It should latch onto the first known hash and ignore the rest.
         // In this test we swop the hash order and expect it to ignore the
@@ -164,7 +170,8 @@ mod stop_hash_is_zero {
     }
 
     #[tokio::test]
-    async fn off_chain_correction() {
+    #[allow(non_snake_case)]
+    async fn c017_t7_GET_HEADERS_off_chain_correction() {
         // Test that we get corrected if we are "off chain".
         // We expect that unknown hashes get ignored, until it finds a known hash; it then returns
         // all known children of that block.
@@ -190,7 +197,8 @@ mod stop_hash_is_start_hash {
     use super::*;
 
     #[tokio::test]
-    async fn from_block_0_to_0() {
+    #[allow(non_snake_case)]
+    async fn c017_t8_GET_HEADERS_from_block_0_to_0() {
         // zcashd: fail (sends all blocks[1+] - same behaviour as if query was not range limited)
         let index = 0;
         let response = run_test_case(GetHeaders::from_indices(index, Some(index)))
@@ -201,7 +209,8 @@ mod stop_hash_is_start_hash {
     }
 
     #[tokio::test]
-    async fn from_block_4_to_4() {
+    #[allow(non_snake_case)]
+    async fn c017_t9_GET_HEADERS_from_block_4_to_4() {
         // zcashd: fail (sends all blocks[5+] - same behaviour as if query was not range limited)
         let index = 4;
         let response = run_test_case(GetHeaders::from_indices(index, Some(index)))
@@ -212,7 +221,8 @@ mod stop_hash_is_start_hash {
     }
 
     #[tokio::test]
-    async fn from_final_block_to_final_block() {
+    #[allow(non_snake_case)]
+    async fn c017_t10_GET_HEADERS_from_final_block_to_final_block() {
         // zcashd: pass
         let index = SEED_BLOCKS.len() - 1;
         let response = run_test_case(GetHeaders::from_indices(index, Some(index)))
@@ -227,7 +237,8 @@ mod ranged {
     use super::*;
 
     #[tokio::test]
-    async fn from_block_0_to_1() {
+    #[allow(non_snake_case)]
+    async fn c017_t11_GET_HEADERS_from_block_0_to_1() {
         // zcashd: pass
         let range = (0, 1);
         let response = run_test_case(GetHeaders::from_indices(range.0, Some(range.1)))
@@ -238,7 +249,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_block_0_to_5() {
+    #[allow(non_snake_case)]
+    async fn c017_t12_GET_HEADERS_from_block_0_to_5() {
         // zcashd: pass
         let range = (0, 5);
         let response = run_test_case(GetHeaders::from_indices(range.0, Some(range.1)))
@@ -249,7 +261,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_block_0_to_final_block() {
+    #[allow(non_snake_case)]
+    async fn c017_t13_GET_HEADERS_from_block_0_to_final_block() {
         // zcashd: pass
         let range = (0, SEED_BLOCKS.len() - 1);
         let response = run_test_case(GetHeaders::from_indices(range.0, Some(range.1)))
@@ -260,7 +273,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_block_3_to_9() {
+    #[allow(non_snake_case)]
+    async fn c017_t14_GET_HEADERS_from_block_3_to_9() {
         // zcashd: pass
         let range = (3, 9);
         let response = run_test_case(GetHeaders::from_indices(range.0, Some(range.1)))
@@ -271,7 +285,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn from_penultimate_block_to_final_block() {
+    #[allow(non_snake_case)]
+    async fn c017_t15_GET_HEADERS_from_penultimate_block_to_final_block() {
         // zcashd: pass
         let range = (SEED_BLOCKS.len() - 2, SEED_BLOCKS.len() - 1);
         let response = run_test_case(GetHeaders::from_indices(range.0, Some(range.1)))
@@ -282,7 +297,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn off_chain_correction() {
+    #[allow(non_snake_case)]
+    async fn c017_t16_GET_HEADERS_off_chain_correction() {
         // Test that we get corrected if we are "off chain".
         // We expect that unknown hashes get ignored, until it finds a known hash; it then returns
         // all known children of that block.
@@ -303,7 +319,8 @@ mod ranged {
     }
 
     #[tokio::test]
-    async fn stop_hash_off_chain() {
+    #[allow(non_snake_case)]
+    async fn c017_t17_GET_HEADERS_stop_hash_off_chain() {
         // Sends a query for all blocks starting from [3], but with
         // a stop_hash that does not match any block on the chain.
         // We expect the node to send all blocks from [3] onwards since the

--- a/src/tests/conformance/unsolicited_response.rs
+++ b/src/tests/conformance/unsolicited_response.rs
@@ -19,7 +19,8 @@ use crate::{
 };
 
 #[tokio::test]
-async fn pong() {
+#[allow(non_snake_case)]
+async fn c010_t1_PONG() {
     // zcashd: pass
     // zebra:  pass
     run_test_case(Message::Pong(Nonce::default()))
@@ -28,7 +29,8 @@ async fn pong() {
 }
 
 #[tokio::test]
-async fn headers() {
+#[allow(non_snake_case)]
+async fn c010_t2_HEADERS() {
     // zcashd: pass
     // zebra:  pass
     run_test_case(Message::Headers(Headers::empty()))
@@ -37,14 +39,16 @@ async fn headers() {
 }
 
 #[tokio::test]
-async fn addr() {
+#[allow(non_snake_case)]
+async fn c010_t3_ADDR() {
     // zcashd: pass
     // zebra:  pass
     run_test_case(Message::Addr(Addr::empty())).await.unwrap();
 }
 
 #[tokio::test]
-async fn block() {
+#[allow(non_snake_case)]
+async fn c010_t4_BLOCK() {
     // zcashd: pass
     // zebra:  pass
     run_test_case(Message::Block(Box::new(Block::testnet_genesis())))
@@ -53,7 +57,8 @@ async fn block() {
 }
 
 #[tokio::test]
-async fn not_found() {
+#[allow(non_snake_case)]
+async fn c010_t5_NOT_FOUND() {
     // zcashd: pass
     // zebra:  pass
     run_test_case(Message::NotFound(Inv::new(vec![
@@ -64,7 +69,8 @@ async fn not_found() {
 }
 
 #[tokio::test]
-async fn tx() {
+#[allow(non_snake_case)]
+async fn c010_t6_TX() {
     // zcashd: pass
     // zebra:  pass
     run_test_case(Message::Tx(Block::testnet_2().txs[0].clone()))

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -51,7 +51,7 @@ const METRIC_REJECTED: &str = "perf_conn_rejected";
 const METRIC_ERROR: &str = "perf_conn_error";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn load_bearing() {
+async fn p002_connections_load_bearing() {
     // ZG-PERFORMANCE-002
     //
     // The node sheds or rejects connections when necessary.

--- a/src/tests/performance/getdata_blocks.rs
+++ b/src/tests/performance/getdata_blocks.rs
@@ -18,7 +18,8 @@ use crate::{
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn throughput() {
+#[allow(non_snake_case)]
+async fn p001_t2_GET_DATA_BLOCKS_throughput() {
     // ZG-PERFORMANCE-001, GetData-Block latency
     //
     // The node behaves as expected under load from other peers.

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -16,7 +16,8 @@ const PINGS: u16 = 1000;
 const METRIC_LATENCY: &str = "ping_perf_latency";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn throughput() {
+#[allow(non_snake_case)]
+async fn p001_t1_PING_PONG_throughput() {
     // ZG-PERFORMANCE-001, Ping-Pong latency
     //
     // The node behaves as expected under load from other peers.

--- a/src/tests/resistance/corrupt_message/bad_checksum.rs
+++ b/src/tests/resistance/corrupt_message/bad_checksum.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn instead_of_version_when_node_receives_connection() {
+async fn r001_t5_instead_of_version_when_node_receives_connection() {
     // ZG-RESISTANCE-001 (part 5)
     //
     // zebra: sends a version before disconnecting.
@@ -54,7 +54,7 @@ async fn instead_of_version_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_receives_connection() {
+async fn r002_t5_instead_of_verack_when_node_receives_connection() {
     // ZG-RESISTANCE-002 (part 5)
     //
     // zebra: sends a verack before disconnecting.
@@ -94,7 +94,7 @@ async fn instead_of_verack_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_version_when_node_initiates_connection() {
+async fn r003_t5_instead_of_version_when_node_initiates_connection() {
     // ZG-RESISTANCE-003 (part 5)
     //
     // zebra: disconnects immediately.
@@ -153,7 +153,7 @@ async fn instead_of_version_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_initiates_connection() {
+async fn r004_t5_instead_of_verack_when_node_initiates_connection() {
     // ZG-RESISTANCE-004 (part 5)
     //
     // zebra: disconnects immediately.
@@ -215,7 +215,7 @@ async fn instead_of_verack_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn post_handshake() {
+async fn r005_t5_post_handshake() {
     // ZG-RESISTANCE-005 (part 5)
     //
     // zebra: disconnects.

--- a/src/tests/resistance/corrupt_message/bad_length.rs
+++ b/src/tests/resistance/corrupt_message/bad_length.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn instead_of_version_when_node_receives_connection() {
+async fn r001_t6_tinstead_of_version_when_node_receives_connection() {
     // ZG-RESISTANCE-001 (part 6)
     //
     // zebra: sends version before disconnecting.
@@ -54,7 +54,7 @@ async fn instead_of_version_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_receives_connection() {
+async fn r002_t6_instead_of_verack_when_node_receives_connection() {
     // ZG-RESISTANCE-002 (part 6)
     //
     // zebra: disconnects.
@@ -94,7 +94,7 @@ async fn instead_of_verack_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_version_when_node_initiates_connection() {
+async fn r003_t6_instead_of_version_when_node_initiates_connection() {
     // ZG-RESISTANCE-003 (part 6)
     //
     // zebra: disconnects
@@ -154,7 +154,7 @@ async fn instead_of_version_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_initiates_connection() {
+async fn r004_t6_instead_of_verack_when_node_initiates_connection() {
     // ZG-RESISTANCE-004 (part 6)
     //
     // zebra: disconnects, logs:
@@ -219,7 +219,7 @@ async fn instead_of_verack_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn post_handshake() {
+async fn r005_t6_post_handshake() {
     // ZG-RESISTANCE-005 (part 6)
     //
     // zebra: disconnects.

--- a/src/tests/resistance/corrupt_message/mod.rs
+++ b/src/tests/resistance/corrupt_message/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn instead_of_version_when_node_receives_connection() {
+async fn r001_t4_instead_of_version_when_node_receives_connection() {
     // ZG-RESISTANCE-001 (part 4)
     //
     // zebra: responds with a version before disconnecting (however, quite slow running).
@@ -50,7 +50,7 @@ async fn instead_of_version_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_receives_connection() {
+async fn r002_t4_instead_of_verack_when_node_receives_connection() {
     // ZG-RESISTANCE-002 (part 4)
     //
     // zebra: responds with verack before disconnecting (however, quite slow running).
@@ -88,7 +88,7 @@ async fn instead_of_verack_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_version_when_node_initiates_connection() {
+async fn r003_t4_instead_of_version_when_node_initiates_connection() {
     // ZG-RESISTANCE-003 (part 4)
     //
     // zebra: disconnects immediately.
@@ -148,7 +148,7 @@ async fn instead_of_version_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_initiates_connection() {
+async fn r004_t4_instead_of_verack_when_node_initiates_connection() {
     // ZG-RESISTANCE-004 (part 4)
     //
     // zebra: disconnects immediately.
@@ -211,7 +211,7 @@ async fn instead_of_verack_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn post_handshake() {
+async fn r005_t4_post_handshake() {
     // ZG-RESISTANCE-005 (part 4)
     //
     // zebra: sends getdata and ignores message.

--- a/src/tests/resistance/corrupt_message/random_payload.rs
+++ b/src/tests/resistance/corrupt_message/random_payload.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn instead_of_version_when_node_receives_connection() {
+async fn r001_t3_instead_of_version_when_node_receives_connection() {
     // ZG-RESISTANCE-001 (part 3)
     //
     // zebra: breaks with a version command in header, otherwise sends verack before closing the
@@ -47,7 +47,7 @@ async fn instead_of_version_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_receives_connection() {
+async fn r002_t3_instead_of_verack_when_node_receives_connection() {
     // ZG-RESISTANCE-002 (part 3)
     //
     // zebra: breaks with a version command in header, otherwise sends verack before closing the
@@ -84,7 +84,7 @@ async fn instead_of_verack_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_version_when_node_initiates_connection() {
+async fn r003_t3_instead_of_version_when_node_initiates_connection() {
     // ZG-RESISTANCE-003 (part 3)
     //
     // zebra: breaks with a version command in header, otherwise sends verack before closing the
@@ -143,7 +143,7 @@ async fn instead_of_version_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_initiates_connection() {
+async fn r004_t3_instead_of_verack_when_node_initiates_connection() {
     // ZG-RESISTANCE-004 (part 3)
     //
     // zebra: breaks with a version command in header, otherwise sends verack before closing the
@@ -206,7 +206,7 @@ async fn instead_of_verack_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn post_handshake() {
+async fn r005_t3_post_handshake() {
     // ZG-RESISTANCE-005 (part 3)
     //
     // zebra: breaks with a version command in header, spams getdata, doesn't disconnect.

--- a/src/tests/resistance/random_bytes.rs
+++ b/src/tests/resistance/random_bytes.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn instead_of_version_when_node_receives_connection() {
+async fn r001_t2_instead_of_version_when_node_receives_connection() {
     // ZG-RESISTANCE-001 (part 2)
     //
     // zebra: sends a version before disconnecting.
@@ -45,7 +45,7 @@ async fn instead_of_version_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_receives_connection() {
+async fn r002_t2_instead_of_verack_when_node_receives_connection() {
     // ZG-RESISTANCE-002 (part 2)
     //
     // zebra: responds with verack before disconnecting.
@@ -82,7 +82,7 @@ async fn instead_of_verack_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_version_when_node_initiates_connection() {
+async fn r003_t2_instead_of_version_when_node_initiates_connection() {
     // ZG-RESISTANCE-003 (part 2)
     //
     // zebra: disconnects immediately.
@@ -139,7 +139,7 @@ async fn instead_of_version_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_initiates_connection() {
+async fn r004_t2_instead_of_verack_when_node_initiates_connection() {
     // ZG-RESISTANCE-004 (part 2)
     //
     // zebra: disconnects immediately.
@@ -197,7 +197,7 @@ async fn instead_of_verack_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn post_handshake() {
+async fn r005_t2_post_handshake() {
     // ZG-RESISTANCE-005 (part 2)
     //
     // zebra: disconnects.

--- a/src/tests/resistance/stress_test.rs
+++ b/src/tests/resistance/stress_test.rs
@@ -72,7 +72,7 @@ const CORRUPT_REPLY: &str = "fuzz_flood_corrupt_reply";
 const CORRUPT_IGNORED: &str = "fuzz_flood_corrupt_ignored";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn throughput() {
+async fn r006_stress_test_throughput() {
     // ZG-RESISTANCE-006
     //
     // Simulate high load situations, while also sending corrupt messages.

--- a/src/tests/resistance/zeroes.rs
+++ b/src/tests/resistance/zeroes.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn instead_of_version_when_node_receives_connection() {
+async fn r001_t1_instead_of_version_when_node_receives_connection() {
     // ZG-RESISTANCE-001 (part 1)
     //
     // zebra: sends a version before disconnecting.
@@ -48,7 +48,7 @@ async fn instead_of_version_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_receives_connection() {
+async fn r002_t1_instead_of_verack_when_node_receives_connection() {
     // ZG-RESISTANCE-002 (part 1)
     //
     // zebra: responds with verack before disconnecting.
@@ -85,7 +85,7 @@ async fn instead_of_verack_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_version_when_node_initiates_connection() {
+async fn r003_t1_instead_of_version_when_node_initiates_connection() {
     // ZG-RESISTANCE-003 (part 1)
     //
     // zebra: disconnects immediately.
@@ -142,7 +142,7 @@ async fn instead_of_version_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn instead_of_verack_when_node_initiates_connection() {
+async fn r004_t1_instead_of_verack_when_node_initiates_connection() {
     // ZG-RESISTANCE-004 (part 1)
     //
     // zebra: disconnects immediately.
@@ -202,7 +202,7 @@ async fn instead_of_verack_when_node_initiates_connection() {
 }
 
 #[tokio::test]
-async fn post_handshake() {
+async fn r005_t1_post_handshake() {
     // ZG-RESISTANCE-005 (part 1)
     //
     // zebra: disconnects.


### PR DESCRIPTION
Tests should adhere to the new test naming convention, i.e `id_part_t(subtest_no)_(message type)_(extra_test_desc)`.
 
Progress:
- [x] Conformance
- [x] Performance
- [x] Resistance
- [x] Update `SPEC.md`