### PR TITLE
Introduce crawler workflow

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -59,4 +59,6 @@ jobs:
           # Send SIGINT after 30 min.
           sleep 1800s
           kill -2 $(pidof crawler)
+          # Wait for shutdown to complete.
+          sleep 30s
           cat crawler-log.txt

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -52,24 +52,21 @@ jobs:
           chmod +x zcash/fetch-params.sh
           ./zcash/fetch-params.sh
       - name: Begin crawling
-        continue-on-error: true
         env:
           FILENAME: ${{ github.event.repository.updated_at }}
         run: |
           chmod +x zcash/zcashd
           ./zcash/zcashd &
           cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 --rpc-addr 127.0.0.1:54321 &
-          # Send SIGINT after 30 min.
+          # After 30 min, query rpc and send SIGINT.
           sleep 1800s
-          kill -2 $(pidof crawler) $(pidof zcashd)
-          # Wait for shutdown to complete.
-          sleep 120s
-          mkdir -p results/crawler
-          # Query rpc.
           curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > $FILENAME.json
+          kill -2 $(pidof crawler) $(pidof zcashd)
+          # Update results folder.
+          mkdir -p results/crawler
           mv $FILENAME.json results/crawler
-          rm -f results/crawler/latest.txt
-          cp results/crawler/$FILENAME.txt results/crawler/latest.json
+          rm -f results/crawler/latest.json
+          cp results/crawler/$FILENAME.json results/crawler/latest.json
       - name: git
         run: |
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -56,8 +56,7 @@ jobs:
           chmod +x zcash/zcashd
           ./zcash/zcashd &
           cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 &
-          # Send SIGINT after 1 min.
-          sleep 60s
-          ps
-          killall -INT cargo
+          # Send SIGINT after 30 min.
+          sleep 1800s
+          kill -2 $(pidof crawler)
           cat crawler-log.txt

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -27,7 +27,6 @@ jobs:
   crawl-network:
     runs-on: ubuntu-latest
     needs: [ install-zcashd ]
-    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -56,6 +55,9 @@ jobs:
         run: |
           chmod +x zcash/zcashd
           ./zcash/zcashd &
-          # Wait for zcashd to finish startup sequence.
-          sleep 30s
-          cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345
+          cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 &
+          # Send SIGINT after 1 min.
+          sleep 60s
+          ps
+          killall -INT cargo
+          cat crawler-log.txt

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -3,7 +3,7 @@ name: crawler
 on:
   workflow_dispatch:    
   push:
-    branches: [ "crawler-ci" ]
+    branches: [ "main" ]
 
 jobs:
   install-zcashd:

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -58,17 +58,18 @@ jobs:
         run: |
           chmod +x zcash/zcashd
           ./zcash/zcashd &
-          cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 &
+          cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 --rpc-addr 127.0.0.1:54321 &
           # Send SIGINT after 30 min.
           sleep 1800s
           kill -2 $(pidof crawler) $(pidof zcashd)
           # Wait for shutdown to complete.
           sleep 120s
           mkdir -p results/crawler
-          mv crawler-log.txt results/crawler/$FILENAME.txt
+          # Query rpc.
+          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > $FILENAME.json
+          mv $FILENAME.json results/crawler
           rm -f results/crawler/latest.txt
-          cp results/crawler/$FILENAME.txt results/crawler/latest.txt
-          ls -Rla
+          cp results/crawler/$FILENAME.txt results/crawler/latest.json
       - name: git
         run: |
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -1,0 +1,61 @@
+name: crawler
+
+on:
+  workflow_dispatch:    
+  push:
+    branches: [ "crawler-ci" ]
+
+jobs:
+  install-zcashd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: clone zcashd
+        run: git clone https://github.com/zcash/zcash
+      - name: build zcashd
+        run: |
+          cd zcash
+          ./zcutil/build.sh -j$(nproc)
+      - uses: actions/upload-artifact@v2
+        with:
+          name: zcashd-fetch-params
+          path: ./zcash/zcutil/fetch-params.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: zcashd-executable
+          path: ./zcash/src/zcashd
+
+  crawl-network:
+    runs-on: ubuntu-latest
+    needs: [ install-zcashd ]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions/download-artifact@v3
+        with:
+          name: zcashd-fetch-params
+          path: ./zcash
+      - uses: actions/download-artifact@v3
+        with:
+          name: zcashd-executable
+          path: ./zcash
+      - name: Create ~/.zcash/zcash.conf
+        run: |
+          mkdir ~/.zcash/
+          touch ~/.zcash/zcash.conf
+          echo bind=127.0.0.1:12345 > ~/.zcash/zcash.conf
+      - name: Fetch zcashd params
+        run: |
+          chmod +x zcash/fetch-params.sh
+          ./zcash/fetch-params.sh
+      - name: Begin crawling
+        run: |
+          chmod +x zcash/zcashd
+          ./zcash/zcashd &
+          # Wait for zcashd to finish startup sequence.
+          sleep 30s
+          cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -52,13 +52,27 @@ jobs:
           chmod +x zcash/fetch-params.sh
           ./zcash/fetch-params.sh
       - name: Begin crawling
+        continue-on-error: true
+        env:
+          FILENAME: ${{ github.event.repository.updated_at }}
         run: |
           chmod +x zcash/zcashd
           ./zcash/zcashd &
           cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 &
           # Send SIGINT after 30 min.
           sleep 1800s
-          kill -2 $(pidof crawler)
+          kill -2 $(pidof crawler) $(pidof zcashd)
           # Wait for shutdown to complete.
-          sleep 30s
-          cat crawler-log.txt
+          sleep 120s
+          mkdir -p results/crawler
+          mv crawler-log.txt results/crawler/$FILENAME.txt
+          rm -f results/crawler/latest.txt
+          cp results/crawler/$FILENAME.txt results/crawler/latest.txt
+          ls -Rla
+      - name: git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add results
+          git commit -m "ci: crawler results"
+          git push


### PR DESCRIPTION
This PR introduces a new CI workflow wherein we crawl the network for ~30 min, logging each run under a new subdirectory: `results/crawler`.