### PR TITLE
Introduce ci for zebra

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -1,9 +1,8 @@
 name: crawler
 
 on:
-  workflow_dispatch:    
-  push:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
   install-zcashd:
@@ -53,7 +52,7 @@ jobs:
           ./zcash/fetch-params.sh
       - name: Begin crawling
         env:
-          FILENAME: ${{ github.event.repository.updated_at }}
+          FILENAME: $(date +%Y-%m-%d)
         run: |
           chmod +x zcash/zcashd
           ./zcash/zcashd &

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -84,10 +84,10 @@ jobs:
           chmod +x zcash/zcashd
           mkdir -p results/zcashd
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zcashd/$FILENAME.jsonl
-          rm -f results/zcashd/latest.jsonl
-          cp results/zcashd/$FILENAME.jsonl results/zcashd/latest.jsonl
       - name: git
         run: |
+          rm -f results/zcashd/latest.jsonl
+          cp results/zcashd/$FILENAME.jsonl results/zcashd/latest.jsonl
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git pull

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -1,9 +1,8 @@
 name: zcashd-nightly
 
 on:
-  workflow_dispatch:    
-  push:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
   install-zcashd:
@@ -84,7 +83,7 @@ jobs:
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > result.jsonl
       - name: git
         env:
-          FILENAME: ${{ github.event.repository.updated_at }}
+          FILENAME: $(date +%Y-%m-%d)
         run: |
           mv result.jsonl results/zcashd/$FILENAME.jsonl
           rm -f results/zcashd/latest.jsonl

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -3,7 +3,7 @@ name: zcashd-nightly
 on:
   workflow_dispatch:    
   push:
-    branches: [ "main" ]
+    branches: [ "zebra-ci" ]
 
 jobs:
   install-zcashd:
@@ -82,14 +82,15 @@ jobs:
           mv ./ziggurat/ziggurat-* ziggurat_test
           chmod +x ziggurat_test
           chmod +x zcash/zcashd
-          mkdir -p results
-          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/$FILENAME.jsonl
-          rm -r results/latest.jsonl
-          cp results/$FILENAME.jsonl results/latest.jsonl
+          mkdir -p results/zcashd
+          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zcashd/$FILENAME.jsonl
+          rm -f results/zcashd/latest.jsonl
+          cp results/zcashd/$FILENAME.jsonl results/zcashd/latest.jsonl
       - name: git
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
+          git pull
           git add results
           git commit -m "ci: zcashd suite results"
           git push

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -3,7 +3,7 @@ name: zcashd-nightly
 on:
   workflow_dispatch:    
   push:
-    branches: [ "zebra-ci" ]
+    branches: [ "main" ]
 
 jobs:
   install-zcashd:

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -75,17 +75,18 @@ jobs:
           ./zcash/fetch-params.sh
       - name: Run ziggurat suite
         continue-on-error: true
-        env:
-          FILENAME: ${{ github.event.repository.updated_at }}
         run: |
           rm ./ziggurat/*.d
           mv ./ziggurat/ziggurat-* ziggurat_test
           chmod +x ziggurat_test
           chmod +x zcash/zcashd
           mkdir -p results/zcashd
-          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zcashd/$FILENAME.jsonl
+          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > result.jsonl
       - name: git
+        env:
+          FILENAME: ${{ github.event.repository.updated_at }}
         run: |
+          mv result.jsonl results/zcashd/$FILENAME.jsonl
           rm -f results/zcashd/latest.jsonl
           cp results/zcashd/$FILENAME.jsonl results/zcashd/latest.jsonl
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -47,6 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-zebra, build-ziggurat ]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v3
         with:
           name: zebra-executable
@@ -65,11 +68,23 @@ jobs:
           echo kind = \"zebra\" >> ~/.ziggurat/config.toml
           echo path = \"/home/runner/work/ziggurat/ziggurat/zebrad\" >> ~/.ziggurat/config.toml
           echo start_command = \"./zebrad start\" >> ~/.ziggurat/config.toml
-      # - name: Download Zebra params
-      #   run: |
-      #     ./zebrad/zebrad download
-      - run: |
+      - name: Run ziggurat suite
+        continue-on-error: true
+        env:
+          FILENAME: ${{ github.event.repository.updated_at }}
+        run: |
           rm ./ziggurat/*.d
           mv ./ziggurat/ziggurat-* ziggurat_test
           chmod +x ziggurat_test
-          ./ziggurat_test --test-threads=1 -Z unstable-options --format json
+          mkdir -p results/zebra
+          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zebra/$FILENAME.jsonl
+          rm -f results/zebra/latest.jsonl
+          cp results/zebra/$FILENAME.jsonl results/zebra/latest.jsonl
+      - name: git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git pull
+          git add results
+          git commit -m "ci: zebra suite results"
+          git push

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -3,7 +3,7 @@ name: Zebra
 on:
   workflow_dispatch:    
   push:
-    branches: [ "main" ]
+    branches: [ "zebra-ci" ]
 
 jobs:
   build-zebra:
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - name: build Zebra and download artifacts
         run: cargo +stable build --release
@@ -63,11 +63,11 @@ jobs:
           mkdir ~/.ziggurat/
           touch ~/.ziggurat/config.toml
           echo kind = \"zebra\" >> ~/.ziggurat/config.toml
-          echo path = \"zebra\" >> ~/.ziggurat/config.toml
-          echo start_command = \"../zebrad/zebrad start\" >> ~/.ziggurat/config.toml
-      - name: Download Zebra params
-        run: |
-          ./zebrad/zebrad download
+          echo path = \"/home/runner/work/ziggurat/ziggurat/zebrad\" >> ~/.ziggurat/config.toml
+          echo start_command = \"./zebrad start\" >> ~/.ziggurat/config.toml
+      # - name: Download Zebra params
+      #   run: |
+      #     ./zebrad/zebrad download
       - run: |
           rm ./ziggurat/*.d
           mv ./ziggurat/ziggurat-* ziggurat_test

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -3,7 +3,7 @@ name: Zebra
 on:
   workflow_dispatch:    
   push:
-    branches: [ "zebra-ci" ]
+    branches: [ "main" ]
 
 jobs:
   build-zebra:

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -77,9 +77,12 @@ jobs:
           mv ./ziggurat/ziggurat-* ziggurat_test
           chmod +x ziggurat_test
           mkdir -p results/zebra
-          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zebra/$FILENAME.jsonl
+          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > result.jsonl
       - name: git
+        env:
+          FILENAME: ${{ github.event.repository.updated_at }}
         run: |
+          mv result.jsonl results/zebra/$FILENAME.jsonl
           rm -f results/zebra/latest.jsonl
           cp results/zebra/$FILENAME.jsonl results/zebra/latest.jsonl
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -1,9 +1,8 @@
 name: Zebra
 
 on:
-  workflow_dispatch:    
-  push:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
   build-zebra:
@@ -71,7 +70,7 @@ jobs:
       - name: Run ziggurat suite
         continue-on-error: true
         env:
-          FILENAME: ${{ github.event.repository.updated_at }}
+          FILENAME: $(date +%Y-%m-%d)
         run: |
           rm ./ziggurat/*.d
           mv ./ziggurat/ziggurat-* ziggurat_test

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -78,10 +78,10 @@ jobs:
           chmod +x ziggurat_test
           mkdir -p results/zebra
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zebra/$FILENAME.jsonl
-          rm -f results/zebra/latest.jsonl
-          cp results/zebra/$FILENAME.jsonl results/zebra/latest.jsonl
       - name: git
         run: |
+          rm -f results/zebra/latest.jsonl
+          cp results/zebra/$FILENAME.jsonl results/zebra/latest.jsonl
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git pull


### PR DESCRIPTION
Similarly to `zcashd`, this PR introduces a new workflow for running `zebra` nodes through the suite. Results are logged as before, but now under a new subdirectory path per node, i.e `results/zcashd` for `zcashd` and `results/zebra` for `zebra`. The PR also migrates the previous trigger-on-push behaviour to schedule runs each day. As an added bonus, this PR also fixes a small issue that prevented the workflow from also logging the `latest.jsonl`.