### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -14,11 +14,11 @@ jobs:
         run: |
           cd zcash
           ./zcutil/build.sh -j$(nproc)
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: zcashd-fetch-params
           path: ./zcash/zcutil/fetch-params.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: zcashd-executable
           path: ./zcash/src/zcashd
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ install-zcashd ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -25,13 +25,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -41,14 +41,14 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
           components: clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -58,14 +58,14 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -75,13 +75,13 @@ jobs:
   check-crawler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -14,11 +14,11 @@ jobs:
         run: |
           cd zcash
           ./zcutil/build.sh -j$(nproc)
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: zcashd-fetch-params
           path: ./zcash/zcutil/fetch-params.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: zcashd-executable
           path: ./zcash/src/zcashd
@@ -26,18 +26,18 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-targets --no-run
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ziggurat-executable
           path: ./target/debug/deps/ziggurat-*
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ check, install-zcashd ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/download-artifact@v3

--- a/.github/workflows/zcashd.yml
+++ b/.github/workflows/zcashd.yml
@@ -2,8 +2,6 @@ name: zcashd
 
 on:
   workflow_dispatch:    
-  push:
-    branches: [ "main" ]
 
 jobs:
   install-zcashd:
@@ -15,11 +13,11 @@ jobs:
         run: |
           cd zcash
           ./zcutil/build.sh -j$(nproc)
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: zcashd-fetch-params
           path: ./zcash/zcutil/fetch-params.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: zcashd-executable
           path: ./zcash/src/zcashd
@@ -27,18 +25,18 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-targets --no-run
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ziggurat-executable
           path: ./target/debug/deps/ziggurat-*
@@ -47,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ check, install-zcashd ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/download-artifact@v3

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -8,7 +8,7 @@ jobs:
   build-zebra:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ZcashFoundation/zebra
       - uses: actions-rs/toolchain@v1
@@ -18,7 +18,7 @@ jobs:
           override: true
       - name: build Zebra and download artifacts
         run: cargo +stable build --release
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: zebra-executable
           path: ./target/release/zebrad
@@ -26,18 +26,18 @@ jobs:
   build-ziggurat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-targets --no-run
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ziggurat-executable
           path: ./target/debug/deps/ziggurat-*


### PR DESCRIPTION
With the somewhat recent announcement of deprecating Node 12 in favor of Node 16, we should update our dependencies to their latest versions. See [this post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for more details regarding the change. Also note that, `actions-rs` actions have not gotten updates in quite a while and still run on Node 12.