### PR TITLE
deps(ci): remove `actions-rs`

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -28,11 +28,7 @@ jobs:
     needs: [ install-zcashd ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal
       - uses: actions/download-artifact@v3
         with:
           name: zcashd-fetch-params

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup toolchain install stable --profile minimal
+      - run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,78 +11,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets
+      - run: cargo check --all-targets
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -- --test-threads=1 --ignored
-
+      - run: cargo test -- --test-threads=1 --ignored
 
   clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
-
+      - run: cargo clippy --all-targets -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rustfmt
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
+      - run: cargo fmt --all -- --check
 
   check-crawler:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features=crawler
+      - run: cargo check --features=crawler

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -27,16 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-targets --no-run
+      - name: Compile unit tests
+        run: cargo test --all-targets --no-run
       - uses: actions/upload-artifact@v3
         with:
           name: ziggurat-executable
@@ -49,6 +43,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - run: rustup toolchain install nightly --profile minimal
       - uses: actions/download-artifact@v3
         with:
           name: zcashd-fetch-params

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -11,11 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ZcashFoundation/zebra
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - run: rustup toolchain install stable --profile minimal
       - name: build Zebra and download artifacts
         run: cargo +stable build --release
       - uses: actions/upload-artifact@v3
@@ -27,16 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-targets --no-run
+      - name: Compile unit tests
+        run: cargo test --all-targets --no-run
       - uses: actions/upload-artifact@v3
         with:
           name: ziggurat-executable
@@ -49,6 +39,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - run: rustup toolchain install nightly --profile minimal
       - uses: actions/download-artifact@v3
         with:
           name: zebra-executable


### PR DESCRIPTION
Replaces all the `actions-rs` actions with standard `rustup/cargo` commands now that `actions-rs` is no longer maintained.