### PR TITLE
feat(ci): compress results

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -53,7 +53,7 @@ jobs:
           ./zcash/zcashd &
           cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 --rpc-addr 127.0.0.1:54321 &
           # After 30 min, query rpc and send SIGINT.
-          sleep 1800s
+          sleep 30m
           curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > $FILENAME.json
           kill -2 $(pidof crawler) $(pidof zcashd)
           # Update results folder.
@@ -61,6 +61,7 @@ jobs:
           mv $FILENAME.json results/crawler
           rm -f results/crawler/latest.json
           cp results/crawler/$FILENAME.json results/crawler/latest.json
+          gzip results/crawler/$FILENAME.json
       - name: git
         run: |
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -75,16 +75,17 @@ jobs:
           chmod +x ziggurat_test
           chmod +x zcash/zcashd
           mkdir -p results/zcashd
-          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > result.jsonl
+          rm -f results/zcashd/latest.jsonl
+          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zcashd/latest.jsonl
       - name: git
         run: |
           FILENAME=$(date +%Y-%m-%d)
-          mv result.jsonl results/zcashd/$FILENAME.jsonl
-          rm -f results/zcashd/latest.jsonl
-          cp results/zcashd/$FILENAME.jsonl results/zcashd/latest.jsonl
+          cd results/zcashd
+          cp latest.jsonl $FILENAME.jsonl
+          gzip $FILENAME.jsonl
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git pull
-          git add results
+          git add ./
           git commit -m "ci: zcashd suite results"
           git push

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -64,16 +64,17 @@ jobs:
           mv ./ziggurat/ziggurat-* ziggurat_test
           chmod +x ziggurat_test
           mkdir -p results/zebra
-          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > result.jsonl
+          rm -f results/zebra/latest.jsonl
+          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zebra/latest.jsonl
       - name: git
         run: |
           FILENAME=$(date +%Y-%m-%d)
-          mv result.jsonl results/zebra/$FILENAME.jsonl
-          rm -f results/zebra/latest.jsonl
-          cp results/zebra/$FILENAME.jsonl results/zebra/latest.jsonl
+          cd results/zebra
+          cp latest.jsonl $FILENAME.jsonl
+          gzip $FILENAME.jsonl
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git pull
-          git add results
+          git add ./
           git commit -m "ci: zebra suite results"
           git push


### PR DESCRIPTION
This PR modifies the test runners + crawler workflow to compress the results before committing. This **should not** affect the GUI, given that the latest result (`latest.jsonl`) will still be kept uncompressed.