### PR TITLE
feat: update crawler to use latest NetworkSummary & spectre

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ pea2pea = "0.45"
 rand = "0.8"
 rand_chacha = "0.3"
 sha2 = "0.10"
-spectre = { git = "https://github.com/niklaslong/spectre", rev = "61bdbf5" }
+spectre = { git = "https://github.com/niklaslong/spectre", rev = "f1d6698" }
 tabled = "0.10"
 time = "0.3"
 toml = "0.6.0"
 ziggurat-core-metrics = { git = "https://github.com/runziggurat/ziggurat-core", tag = "v0.1.2-zgm" }
-ziggurat-core-crawler = { git = "https://github.com/runziggurat/ziggurat-core", rev = "2de7a9d" }
+ziggurat-core-crawler = { git = "https://github.com/runziggurat/ziggurat-core", rev = "001c943" }
 
 [dependencies.clap]
 version = "4.1.4"

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -63,7 +63,7 @@ pub fn new_network_summary(crawler: &Crawler, graph: &Graph<IpAddr>) -> NetworkS
 
     let num_versions = protocol_versions.values().sum();
     let crawler_runtime = crawler.start_time.elapsed();
-    let agraph = graph.create_agraph(&good_nodes);
+    let indices = graph.get_filtered_adjacency_indices(&good_nodes);
 
     NetworkSummary {
         num_known_nodes,
@@ -74,6 +74,6 @@ pub fn new_network_summary(crawler: &Crawler, graph: &Graph<IpAddr>) -> NetworkS
         user_agents,
         crawler_runtime,
         node_ips: good_nodes.iter().map(IpAddr::to_string).collect(),
-        agraph,
+        indices,
     }
 }


### PR DESCRIPTION
I've updated the zcash crawler to use:
- new spectre API to fetch indices
- remove AGraph as struct, using updated NetworkSummary

I have run the zcash crawler per normal, and got a correctly formed sample.json back (e.g., using the `indices` field in NetworkSummary, rather than `agraph`.
