### PR TITLE
fix: always procure crawler runtime last

### DIFF
--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -185,6 +185,7 @@ async fn main() {
             if delta_time.is_zero() {
                 warn!(parent: crawler.node().span(), "summary calculation took more time than the loop interval");
             }
+            info!(parent: crawler.node().span(), "summary calculation took: {:?}", start_time.elapsed());
 
             thread::sleep(delta_time);
         }

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -62,7 +62,6 @@ pub fn new_network_summary(crawler: &Crawler, graph: &Graph<SocketAddr>) -> Netw
     }
 
     let num_versions = protocol_versions.values().sum();
-    let crawler_runtime = crawler.start_time.elapsed();
     let nodes_indices = graph.get_filtered_adjacency_indices(&good_nodes);
 
     NetworkSummary {
@@ -72,7 +71,7 @@ pub fn new_network_summary(crawler: &Crawler, graph: &Graph<SocketAddr>) -> Netw
         num_versions,
         protocol_versions,
         user_agents,
-        crawler_runtime,
+        crawler_runtime: crawler.start_time.elapsed(),
         node_addrs: good_nodes,
         nodes_indices,
     }


### PR DESCRIPTION
`crawler_runtime` is currently calculated before a function (`get_filtered_adjacency_indices`) that takes a long time to compute, resulting in skewed runtime results. This PR makes sure that `crawler_runtime` only gets procured when returning `NetworkSummary`, and adds a small `info!` line in the summary calculation loop for displaying time taken to run the calculations.