### PR TITLE
feat(ci): display diff from last run

### DIFF
--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -75,18 +75,41 @@ jobs:
           chmod +x ziggurat_test
           chmod +x zcash/zcashd
           mkdir -p results/zcashd
-          rm -f results/zcashd/latest.jsonl
+          mv results/zcashd/latest.jsonl results/zcashd/comparison.jsonl
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zcashd/latest.jsonl
           cat results/zcashd/latest.jsonl
-      - name: Git
+      - name: Process results
         run: |
           FILENAME=$(date +%Y-%m-%d)
           cd results/zcashd
           cp latest.jsonl $FILENAME.jsonl
           gzip $FILENAME.jsonl
+      - name: Compare results
+        run: |
+          # Helper function to remove ignored tests and started ones, and then attributes exec_time and type
+          filter_json() {
+            tmp=$(mktemp)
+            ! jq 'del(select(.event == "ignored"))' $1 > $tmp && mv $tmp $1 # Remove ignored tests
+            jq 'del(select(.event == "started"))' $1 > $tmp && mv $tmp $1 # Remove started tests
+            jq 'del(.exec_time) | del(.type)' $1 > $tmp && mv $tmp $1 # Remove exec_time and type attributes
+            # Remove null characters and empty lines
+            sed -i 's/null//g' $1
+            sed -i '/^$/d' $1
+          }
+          mkdir temp
+          cp results/zcashd/latest.jsonl temp/
+          mv results/zcashd/comparison.jsonl temp/
+          cd temp
+          filter_json latest.jsonl
+          filter_json comparison.jsonl
+          ! diff -u comparison.jsonl latest.jsonl
+          cd ..
+          rm -rf temp
+      - name: Git
+        run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git pull
-          git add ./
+          git add results/zcashd
           git commit -m "ci: zcashd suite results"
           git push

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -64,18 +64,41 @@ jobs:
           mv ./ziggurat/ziggurat-* ziggurat_test
           chmod +x ziggurat_test
           mkdir -p results/zebra
-          rm -f results/zebra/latest.jsonl
+          mv results/zebra/latest.jsonl results/zebra/comparison.jsonl
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/zebra/latest.jsonl
           cat results/zebra/latest.jsonl
-      - name: Git
+      - name: Process results
         run: |
           FILENAME=$(date +%Y-%m-%d)
           cd results/zebra
           cp latest.jsonl $FILENAME.jsonl
           gzip $FILENAME.jsonl
+      - name: Compare results
+        run: |
+          # Helper function to remove ignored tests and started ones, and then attributes exec_time and type
+          filter_json() {
+            tmp=$(mktemp)
+            ! jq 'del(select(.event == "ignored"))' $1 > $tmp && mv $tmp $1 # Remove ignored tests
+            jq 'del(select(.event == "started"))' $1 > $tmp && mv $tmp $1 # Remove started tests
+            jq 'del(.exec_time) | del(.type)' $1 > $tmp && mv $tmp $1 # Remove exec_time and type attributes
+            # Remove null characters and empty lines
+            sed -i 's/null//g' $1
+            sed -i '/^$/d' $1
+          }
+          mkdir temp
+          cp results/zebra/latest.jsonl temp/
+          mv results/zebra/comparison.jsonl temp/
+          cd temp
+          filter_json latest.jsonl
+          filter_json comparison.jsonl
+          ! diff -u comparison.jsonl latest.jsonl
+          cd ..
+          rm -rf temp
+      - name: Git
+        run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git pull
-          git add ./
+          git add results/zebra
           git commit -m "ci: zebra suite results"
           git push


### PR DESCRIPTION
Included with this PR (identical to the `XRPL` one), for both `zcashd` and `zebra`:
- A new step that will display the output of the diff command between the workflows latest run (latest.jsonl) and the one prior to that (comparison.jsonl)
- The json files are modified in a new function, filter_json, to filter out things that would clog the output of diff, e.g exec_time and type.