### PR TITLE
Introduce more CI reusability

### DIFF
--- a/.github/workflows/build-zcashd.yml
+++ b/.github/workflows/build-zcashd.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
 
 jobs:
-  install-zcashd:
+  build-zcashd:
     runs-on: ubuntu-latest
     steps:
       - name: Clone zcashd

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -3,13 +3,10 @@ name: crawler
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
-  push:
-    branches:
-      - reuse-workflow
 
 jobs:
   call-install-zcashd-workflow:
-    uses: zeapoz/zcash/.github/workflows/install-zcashd.yml@reuse-workflow
+    uses: runziggurat/zcash/.github/workflows/install-zcashd.yml@main
 
   crawl-network:
     runs-on: ubuntu-latest
@@ -43,26 +40,21 @@ jobs:
           sleep 30m
           curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > latest.json
           kill -2 $(pidof crawler) $(pidof zcashd)
+      - name: Check for error
+        run: |
           # If the result contains any error, fail workflow
           if grep "error" latest.json; then
             echo "Aborting. Crawler results contained an error"
             exit 1
           fi
           cat latest.json
-      - name: Prepare results
-        run: |
-          FILENAME=$(date +%Y-%m-%d)
-          mkdir -p results/crawler
-          rm -f results/crawler/latest.json
-          mv latest.json results/crawler/latest.json
-          cd results/crawler
-          cp latest.json $FILENAME.json
-          gzip $FILENAME.json
-      - name: Git
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git pull
-          git add results/crawler
-          git commit -m "ci: crawler results"
-          git push
+      - uses: actions/upload-artifact@v3
+        with:
+          name: latest-result
+          path: latest.json
+
+  call-process-results-workflow:
+    needs: [ crawl-network ]
+    uses: runziggurat/zcash/.github/workflows/process-results.yml@main
+    with:
+      name: crawler

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -5,12 +5,12 @@ on:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
-  call-install-zcashd-workflow:
-    uses: runziggurat/zcash/.github/workflows/install-zcashd.yml@main
+  call-build-zcashd-workflow:
+    uses: runziggurat/zcash/.github/workflows/build-zcashd.yml@main
 
   crawl-network:
     runs-on: ubuntu-latest
-    needs: [ call-install-zcashd-workflow ]
+    needs: [ call-build-zcashd-workflow ]
     steps:
       - uses: actions/checkout@v3
       - run: rustup toolchain install stable --profile minimal

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -3,29 +3,17 @@ name: crawler
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
+  push:
+    branches:
+      - reuse-workflow
 
 jobs:
-  install-zcashd:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone zcashd
-        run: git clone https://github.com/zcash/zcash
-      - name: Build zcashd
-        run: |
-          cd zcash
-          ./zcutil/build.sh -j$(nproc)
-      - uses: actions/upload-artifact@v3
-        with:
-          name: zcashd-fetch-params
-          path: ./zcash/zcutil/fetch-params.sh
-      - uses: actions/upload-artifact@v3
-        with:
-          name: zcashd-executable
-          path: ./zcash/src/zcashd
+  call-install-zcashd-workflow:
+    uses: zeapoz/zcash/.github/workflows/install-zcashd.yml@reuse-workflow
 
   crawl-network:
     runs-on: ubuntu-latest
-    needs: [ install-zcashd ]
+    needs: [ call-install-zcashd-workflow ]
     steps:
       - uses: actions/checkout@v3
       - run: rustup toolchain install stable --profile minimal

--- a/.github/workflows/diff-with-previous.yml
+++ b/.github/workflows/diff-with-previous.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_call:
+
+jobs:
+  diff-with-previous:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: latest-result
+      - uses: actions/download-artifact@v3
+        with:
+          name: previous-result
+      - name: Compare results
+        run: |
+          # Helper function to remove ignored tests and started ones, and then attributes exec_time and type
+          filter_json() {
+            tmp=$(mktemp)
+            jq 'del(select(.event == "ignored"))' $1 > $tmp && mv $tmp $1 # Remove ignored tests
+            jq 'del(select(.event == "started"))' $1 > $tmp && mv $tmp $1 # Remove started tests
+            jq 'del(.exec_time) | del(.type)' $1 > $tmp && mv $tmp $1 # Remove exec_time and type attributes
+            # Remove null characters and empty lines
+            sed -i 's/null//g' $1
+            sed -i '/^$/d' $1
+          }
+          filter_json latest.jsonl
+          filter_json previous.jsonl
+          diff -u previous.jsonl latest.jsonl

--- a/.github/workflows/install-zcashd.yml
+++ b/.github/workflows/install-zcashd.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_call:
+
+jobs:
+  install-zcashd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone zcashd
+        run: git clone https://github.com/zcash/zcash
+      - name: Build zcashd
+        run: |
+          cd zcash
+          ./zcutil/build.sh -j$(nproc)
+      - uses: actions/upload-artifact@v3
+        with:
+          name: zcashd-fetch-params
+          path: ./zcash/zcutil/fetch-params.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: zcashd-executable
+          path: ./zcash/src/zcashd

--- a/.github/workflows/process-results.yml
+++ b/.github/workflows/process-results.yml
@@ -6,31 +6,6 @@ on:
         type: string
 
 jobs:
-  diff-with-previous:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: latest-result
-      - uses: actions/download-artifact@v3
-        with:
-          name: previous-result
-      - name: Compare results
-        run: |
-          # Helper function to remove ignored tests and started ones, and then attributes exec_time and type
-          filter_json() {
-            tmp=$(mktemp)
-            ! jq 'del(select(.event == "ignored"))' $1 > $tmp && mv $tmp $1 # Remove ignored tests
-            jq 'del(select(.event == "started"))' $1 > $tmp && mv $tmp $1 # Remove started tests
-            jq 'del(.exec_time) | del(.type)' $1 > $tmp && mv $tmp $1 # Remove exec_time and type attributes
-            # Remove null characters and empty lines
-            sed -i 's/null//g' $1
-            sed -i '/^$/d' $1
-          }
-          filter_json latest.jsonl
-          filter_json previous.jsonl
-          ! diff -u previous.jsonl latest.jsonl
-
   process-results:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -5,10 +5,10 @@ on:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
-  call-install-zcashd-workflow:
-    uses: runziggurat/zcash/.github/workflows/install-zcashd.yml@main
+  call-build-zcashd-workflow:
+    uses: runziggurat/zcash/.github/workflows/build-zcashd.yml@main
 
-  install-ziggurat:
+  build-ziggurat:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
 
   test-zcashd:
     runs-on: ubuntu-latest
-    needs: [ install-ziggurat, call-install-zcashd-workflow ]
+    needs: [ build-ziggurat, call-build-zcashd-workflow ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -3,25 +3,13 @@ name: zcashd-nightly
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
+  push:
+    branches:
+      - reuse-workflow
 
 jobs:
-  install-zcashd:
-    runs-on: ubuntu-latest
-    steps:
-      - name: clone zcashd
-        run: git clone https://github.com/zcash/zcash
-      - name: build zcashd
-        run: |
-          cd zcash
-          ./zcutil/build.sh -j$(nproc)
-      - uses: actions/upload-artifact@v3
-        with:
-          name: zcashd-fetch-params
-          path: ./zcash/zcutil/fetch-params.sh
-      - uses: actions/upload-artifact@v3
-        with:
-          name: zcashd-executable
-          path: ./zcash/src/zcashd
+  call-install-zcashd-workflow:
+    uses: zeapoz/zcash/.github/workflows/install-zcashd.yml@reuse-workflow
 
   install-ziggurat:
     runs-on: ubuntu-latest
@@ -38,7 +26,7 @@ jobs:
 
   test-zcashd:
     runs-on: ubuntu-latest
-    needs: [ install-ziggurat, install-zcashd ]
+    needs: [ install-ziggurat, call-install-zcashd-workflow ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -89,6 +77,6 @@ jobs:
 
   call-process-results-workflow:
     needs: [ test-zcashd ]
-    uses: runziggurat/zcash/.github/workflows/process-results.yml@main
+    uses: zeapoz/zcash/.github/workflows/process-results.yml@reuse-workflow
     with:
       name: zcashd

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -3,13 +3,10 @@ name: zcashd-nightly
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
-  push:
-    branches:
-      - reuse-workflow
 
 jobs:
   call-install-zcashd-workflow:
-    uses: zeapoz/zcash/.github/workflows/install-zcashd.yml@reuse-workflow
+    uses: runziggurat/zcash/.github/workflows/install-zcashd.yml@main
 
   install-ziggurat:
     runs-on: ubuntu-latest
@@ -77,6 +74,10 @@ jobs:
 
   call-process-results-workflow:
     needs: [ test-zcashd ]
-    uses: zeapoz/zcash/.github/workflows/process-results.yml@reuse-workflow
+    uses: runziggurat/zcash/.github/workflows/process-results.yml@main
     with:
       name: zcashd
+
+  call-diff-with-previous-workflow:
+    needs: [ test-zcashd ]
+    uses: runziggurat/zcash/.github/workflows/diff-with-previous.yml@main

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -3,9 +3,6 @@ name: zebra
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
-  push:
-    branches:
-      - reuse-workflow
 
 jobs:
   build-zebra:
@@ -81,6 +78,10 @@ jobs:
 
   call-process-results-workflow:
     needs: [ test-zebra ]
-    uses: zeapoz/zcash/.github/workflows/process-results.yml@reuse-workflow
+    uses: runziggurat/zcash/.github/workflows/process-results.yml@main
     with:
       name: zebra
+
+  call-diff-with-previous-workflow:
+    needs: [ test-zebra ]
+    uses: runziggurat/zcash/.github/workflows/diff-with-previous.yml@main

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -3,6 +3,9 @@ name: zebra
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
+  push:
+    branches:
+      - reuse-workflow
 
 jobs:
   build-zebra:
@@ -78,6 +81,6 @@ jobs:
 
   call-process-results-workflow:
     needs: [ test-zebra ]
-    uses: runziggurat/zcash/.github/workflows/process-results.yml@main
+    uses: zeapoz/zcash/.github/workflows/process-results.yml@reuse-workflow
     with:
       name: zebra


### PR DESCRIPTION
- New `install-zcashd` workflow
- Split `process-results` into, `process-results` and `diff-with-previous`
- Modifies `process-results` to be compatible with calls from crawler workflows