### PR TITLE
Allow different file extensions in `process-results`

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -58,3 +58,4 @@ jobs:
     uses: runziggurat/zcash/.github/workflows/process-results.yml@main
     with:
       name: crawler
+      extension: json

--- a/.github/workflows/process-results.yml
+++ b/.github/workflows/process-results.yml
@@ -4,24 +4,30 @@ on:
       name:
         required: true
         type: string
+      extension:
+        type: string
+        default: "jsonl"
 
 jobs:
   process-results:
     runs-on: ubuntu-latest
     env:
       NAME: ${{ inputs.name }}
+      EXTENSION: ${{ inputs.extension }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: latest-result
-          path: results/$NAME/latest.jsonl
+          path: ./
+      - run: |
+          mv latest.$EXTENSION results/$NAME
       - name: Process results
         run: |
           FILENAME=$(date +%Y-%m-%d)
           cd results/$NAME
-          cp latest.jsonl $FILENAME.jsonl
-          gzip $FILENAME.jsonl
+          cp latest.$EXTENSION $FILENAME.$EXTENSION
+          gzip $FILENAME.$EXTENSION
       - name: Git
         run: |
           git config user.name 'github-actions[bot]'

--- a/.github/workflows/process-results.yml
+++ b/.github/workflows/process-results.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           name: latest-result
           path: ./
-      - name: Replace with latest result
+      - name: Replace with the latest result
         run: |
           rm -rf results/$NAME/latest.$EXTENSION
           mv latest.$EXTENSION results/$NAME

--- a/.github/workflows/process-results.yml
+++ b/.github/workflows/process-results.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           name: latest-result
           path: ./
-      - run: |
+      - name: Replace with latest result
+        run: |
+          rm -rf results/$NAME/latest.$EXTENSION
           mv latest.$EXTENSION results/$NAME
       - name: Process results
         run: |


### PR DESCRIPTION
Crawler workflows uses `.json` files, while suite workflows uses `.jsonl` files. This PR allows both extensions to be used in the `process-results` workflow.