### PR TITLE
chore: modify diff output

### DIFF
--- a/.github/workflows/diff-with-previous.yml
+++ b/.github/workflows/diff-with-previous.yml
@@ -15,10 +15,12 @@ jobs:
         run: |
           # Helper function to remove ignored tests and started ones, and then attributes exec_time and type
           filter_json() {
+            # Remove invalid lines (ones that don't start with "{")
+            sed -i '/^{/!d' $1
             tmp=$(mktemp)
-            jq 'del(select(.event == "ignored"))' $1 > $tmp && mv $tmp $1 # Remove ignored tests
-            jq 'del(select(.event == "started"))' $1 > $tmp && mv $tmp $1 # Remove started tests
-            jq 'del(.exec_time) | del(.type)' $1 > $tmp && mv $tmp $1 # Remove exec_time and type attributes
+            jq 'del(select(.event == "ignored"))' $1 > $tmp; mv $tmp $1 # Remove ignored tests
+            jq 'del(select(.event == "started"))' $1 > $tmp; mv $tmp $1 # Remove started tests
+            jq 'del(.exec_time) | del(.type)' $1 > $tmp; mv $tmp $1 # Remove exec_time and type attributes
             # Remove null characters and empty lines
             sed -i 's/null//g' $1
             sed -i '/^$/d' $1


### PR DESCRIPTION
Small tweak to the output of the diffing step, now removing invalid jsonl lines before parsing with `jq`. The new format looks like the following:
```
--- previous.jsonl
+++ latest.jsonl
@@ -52,7 +52,7 @@
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_verack::when_node_receives_connection::c005_t10_INV",
-  "event": "ok"
+  "event": "failed"
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_verack::when_node_receives_connection::c005_t11_NOT_FOUND",
@@ -144,15 +144,15 @@
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_version::when_node_receives_connection::c003_t10_GET_DATA_TX",
-  "event": "failed"
+  "event": "ok"
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_version::when_node_receives_connection::c003_t11_INV",
-  "event": "failed"
+  "event": "ok"
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_version::when_node_receives_connection::c003_t12_NOT_FOUND",
-  "event": "failed"
+  "event": "ok"
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_version::when_node_receives_connection::c003_t1_GET_ADDR",
@@ -164,11 +164,11 @@
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_version::when_node_receives_connection::c003_t3_VERACK",
-  "event": "ok"
+  "event": "failed"
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_version::when_node_receives_connection::c003_t4_PING",
-  "event": "failed"
+  "event": "ok"
 }
 {
   "name": "tests::conformance::handshake::ignore_message_inplace_of_version::when_node_receives_connection::c003_t5_PONG",
@@ -640,8 +640,8 @@
 }
 {
   "event": "failed",
-  "passed": 38,
-  "failed": 122,
+  "passed": 40,
+  "failed": 120,
   "ignored": 27,
   "measured": 0,
   "filtered_out": 0
```