### PR TITLE
fix(ci): modify wildcard placement

### DIFF
--- a/.github/workflows/build-ziggurat.yml
+++ b/.github/workflows/build-ziggurat.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: ziggurat-executable
-          path: ./target/debug/deps/ziggurat-*
+          path: ./target/debug/deps/ziggurat*


### PR DESCRIPTION
Unit tests get compiled under namespace `ziggurat_` on XRPL impl, while they, under the Zcash impl, compiles under `ziggurat-`. This PR simply adjusts the placement of the wildcard to adjust for that.