### PR TITLE
chore: add deps.rs and workflow badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Ziggurat
+[![dependency status](https://deps.rs/repo/github/runziggurat/zcash/status.svg)](https://deps.rs/repo/github/runziggurat/zcash)
+![workflow status](https://github.com/runziggurat/zcash/actions/workflows/zcashd-nightly.yml/badge.svg)
+![workflow status](https://github.com/runziggurat/zcash/actions/workflows/zebra.yml/badge.svg)
 > The Zcash Network Stability Framework
 
 <img src="./logo.png" alt="Ziggurat Logo" width="240" />


### PR DESCRIPTION
This PR addresses the Improvement Bucket Task: `Add deps.rs badges to all our readme documents`
Badges for the two workflows have also been integrated:
- `zcashd-nightly`
- `zebra`