### PR TITLE
feat: node network checker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ parking_lot = "0.12"
 pea2pea = "0.45"
 rand = "0.8"
 rand_chacha = "0.3"
+regex = "1"
 sha2 = "0.10"
 spectre = { git = "https://github.com/niklaslong/spectre", rev = "9a0664f" }
 tabled = "0.10"
 time = "0.3"
 toml = "0.6.0"
-ziggurat-core-metrics = { git = "https://github.com/runziggurat/ziggurat-core", rev = "d8e4e0a" }
-ziggurat-core-crawler = { git = "https://github.com/runziggurat/ziggurat-core", rev = "d8e4e0a" }
+ziggurat-core-metrics = { git = "https://github.com/runziggurat/ziggurat-core", rev = "33ef131" }
+ziggurat-core-crawler = { git = "https://github.com/runziggurat/ziggurat-core", rev = "33ef131" }
 
 [dependencies.clap]
 version = "4.1.4"

--- a/src/protocol/payload/version.rs
+++ b/src/protocol/payload/version.rs
@@ -27,7 +27,7 @@ pub struct Version {
     /// The user agent of the sender.
     pub user_agent: VarStr,
     /// The start last block received by the sender.
-    pub start_height: u32,
+    pub start_height: i32,
     /// Specifies if the receiver should relay transactions.
     pub relay: bool,
 }
@@ -75,7 +75,7 @@ impl Codec for Version {
 
         self.nonce.encode(buffer)?;
         self.user_agent.encode(buffer)?;
-        buffer.put_u32_le(self.start_height);
+        buffer.put_i32_le(self.start_height);
         buffer.put_u8(self.relay as u8);
 
         Ok(())
@@ -92,7 +92,7 @@ impl Codec for Version {
         let nonce = Nonce::decode(bytes)?;
         let user_agent = VarStr::decode(bytes)?;
 
-        let start_height = u32::from_le_bytes(read_n_bytes(bytes)?);
+        let start_height = i32::from_le_bytes(read_n_bytes(bytes)?);
         let relay = u8::from_le_bytes(read_n_bytes(bytes)?) != 0;
 
         Ok(Self {

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -36,6 +36,13 @@ impl NetworkMetrics {
     }
 }
 
+// Updates the node's network type.
+//
+// The decision of whether a node belongs to the Zcash network is based on these factors:
+//  `start_height` - this MUST match
+// and one of the additional factors also must match as an extra confirmation:
+// `port`
+// `agent`
 fn recognize_network_types(
     nodes: &HashMap<SocketAddr, KnownNode>,
     good_nodes: &Vec<SocketAddr>,
@@ -76,14 +83,15 @@ fn recognize_network_types(
             agent_matches = true;
         }
 
+        // Check if the height is alright - this is a mandatory check for any zcash node implementation.
         let height = nodes[node].start_height.unwrap_or(0);
         if height < MIN_BLOCK_HEIGHT {
             node_network_types.push(NetworkType::Unknown);
             continue;
         }
 
-        // Height must match and either port or agent must match to recognize node as zcash node and
-        // there were no conditions that explicitly blocks matching.
+        // When a block height is correct, we still need one additional confirmation:
+        // In rare cases, the agent or the port won't use a commonly used value.
         if port_matches || agent_matches {
             node_network_types.push(NetworkType::Zcash);
         } else {

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -4,7 +4,10 @@ use regex::Regex;
 use spectre::{edge::Edge, graph::Graph};
 use ziggurat_core_crawler::summary::{NetworkSummary, NetworkType};
 
-use crate::{network::LAST_SEEN_CUTOFF, Crawler};
+use crate::{
+    network::{KnownNode, LAST_SEEN_CUTOFF},
+    Crawler,
+};
 
 const MIN_BLOCK_HEIGHT: i32 = 2_000_000;
 const ZCASH_P2P_PORT: u16 = 8233;
@@ -33,6 +36,64 @@ impl NetworkMetrics {
     }
 }
 
+fn recognize_network_types(
+    nodes: &HashMap<SocketAddr, KnownNode>,
+    good_nodes: &Vec<SocketAddr>,
+) -> Vec<NetworkType> {
+    let num_good_nodes = good_nodes.len();
+    let mut node_network_types = Vec::with_capacity(num_good_nodes);
+    for node in good_nodes {
+        let mut agent_matches = false;
+
+        let port_matches = node.port() == ZCASH_P2P_PORT;
+
+        let agent = if let Some(agent) = &nodes[node].user_agent {
+            agent.0.clone()
+        } else {
+            "".to_string()
+        };
+        let zcash_regex = Regex::new(r"^/MagicBean:(\d)\.(\d)\.(\d)/$").unwrap();
+        let zebra_regex = Regex::new(r"^/Zebra:(\d)\.(\d)\.(\d)").unwrap();
+
+        // Look for zcash agent like "/MagicBean:5.4.2/"
+        let cap_zc = zcash_regex.captures(agent.as_str());
+        if let Some(cap) = cap_zc {
+            let major = cap.get(1).unwrap().as_str().parse::<u32>().unwrap();
+            if major < 6 {
+                // Accept all zcash versions < 6 (6 is Flux)
+                agent_matches = true;
+            } else if major == 6 {
+                // Block all zcash versions 6 (Flux) even if they are on the right port
+                node_network_types.push(NetworkType::Unknown);
+                continue;
+            }
+        }
+
+        // Look for zebra agent like "/Zebra:1.0.0-rc.4/"
+        let cap_ze = zebra_regex.captures(agent.as_str());
+        if cap_ze.is_some() {
+            // Accept all zebra versions
+            agent_matches = true;
+        }
+
+        let height = nodes[node].start_height.unwrap_or(0);
+        if height < MIN_BLOCK_HEIGHT {
+            node_network_types.push(NetworkType::Unknown);
+            continue;
+        }
+
+        // Height must match and either port or agent must match to recognize node as zcash node and
+        // there were no conditions that explicitly blocks matching.
+        if port_matches || agent_matches {
+            node_network_types.push(NetworkType::Zcash);
+        } else {
+            node_network_types.push(NetworkType::Unknown);
+        }
+    }
+
+    node_network_types
+}
+
 /// Constructs a new NetworkSummary from given nodes.
 pub fn new_network_summary(crawler: &Crawler, graph: &Graph<SocketAddr>) -> NetworkSummary {
     let nodes = crawler.known_network.nodes();
@@ -52,62 +113,20 @@ pub fn new_network_summary(crawler: &Crawler, graph: &Graph<SocketAddr>) -> Netw
     let mut protocol_versions = HashMap::with_capacity(num_known_nodes);
     let mut user_agents = HashMap::with_capacity(num_known_nodes);
 
-    for (_, node) in nodes.clone() {
+    for (_, node) in nodes.iter() {
         if node.protocol_version.is_some() {
             protocol_versions
                 .entry(node.protocol_version.unwrap().0)
                 .and_modify(|count| *count += 1)
                 .or_insert(1);
             user_agents
-                .entry(node.user_agent.unwrap().0)
+                .entry(node.user_agent.clone().unwrap().0)
                 .and_modify(|count| *count += 1)
                 .or_insert(1);
         }
     }
 
-    let mut node_network_types = Vec::with_capacity(num_good_nodes);
-    for node in &good_nodes {
-        let mut agent_matches = false;
-        let mut blocker = false;
-
-        let port_matches = node.port() == ZCASH_P2P_PORT;
-
-        let agent = if let Some(agent) = &nodes[node].user_agent {
-            agent.0.clone()
-        } else {
-            "".to_string()
-        };
-        let zcash_re = Regex::new(r"^/MagicBean:(\d)\.(\d)\.(\d)/$").unwrap();
-        let zebra_re = Regex::new(r"^/Zebra:(\d)\.(\d)\.(\d)").unwrap();
-
-        let cap_zc = zcash_re.captures(agent.as_str());
-        if let Some(cap) = cap_zc {
-            let major = cap.get(1).unwrap().as_str().parse::<u32>().unwrap();
-            if major < 6 {
-                // Accept all zcash versions < 6 (6 is Flux)
-                agent_matches = true;
-            } else if major == 6 {
-                blocker = true; // Block all zcash versions 6 (Flux) even if they are on the right port
-            }
-        }
-
-        let cap_ze = zebra_re.captures(agent.as_str());
-        if cap_ze.is_some() {
-            // Accept all zebra versions
-            agent_matches = true;
-        }
-
-        let height = nodes[node].start_height.unwrap_or(0);
-        let height_matches = height > MIN_BLOCK_HEIGHT;
-
-        // Height must match and either port or agent must match to recognize node as zcash node and
-        // there were no conditions that explicitly blocks matching.
-        if height_matches && (port_matches || agent_matches) && !blocker {
-            node_network_types.push(NetworkType::Zcash);
-        } else {
-            node_network_types.push(NetworkType::Unknown);
-        }
-    }
+    let node_network_types = recognize_network_types(&nodes, &good_nodes);
 
     let num_versions = protocol_versions.values().sum();
     let nodes_indices = graph.get_filtered_adjacency_indices(&good_nodes);

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -67,14 +67,10 @@ pub fn new_network_summary(crawler: &Crawler, graph: &Graph<SocketAddr>) -> Netw
 
     let mut node_network_types = Vec::with_capacity(num_good_nodes);
     for node in &good_nodes {
-        let mut port_matches = false;
         let mut agent_matches = false;
-        let mut height_matches = false;
         let mut blocker = false;
 
-        if node.port() == ZCASH_P2P_PORT {
-            port_matches = true;
-        }
+        let port_matches = node.port() == ZCASH_P2P_PORT;
 
         let agent = if let Some(agent) = &nodes[node].user_agent {
             agent.0.clone()
@@ -102,9 +98,7 @@ pub fn new_network_summary(crawler: &Crawler, graph: &Graph<SocketAddr>) -> Netw
         }
 
         let height = nodes[node].start_height.unwrap_or(0);
-        if height > MIN_BLOCK_HEIGHT {
-            height_matches = true;
-        }
+        let height_matches = height > MIN_BLOCK_HEIGHT;
 
         // Height must match and either port or agent must match to recognize node as zcash node and
         // there were no conditions that explicitly blocks matching.

--- a/src/tools/crawler/network.rs
+++ b/src/tools/crawler/network.rs
@@ -23,6 +23,8 @@ pub struct KnownNode {
     pub protocol_version: Option<ProtocolVersion>,
     /// The node's user agent.
     pub user_agent: Option<VarStr>,
+    /// The node's best block height.
+    pub start_height: Option<i32>,
     /// The number of services supported by the node.
     pub services: Option<u64>,
     /// The number of subsequent connection errors.

--- a/src/tools/crawler/network.rs
+++ b/src/tools/crawler/network.rs
@@ -23,7 +23,7 @@ pub struct KnownNode {
     pub protocol_version: Option<ProtocolVersion>,
     /// The node's user agent.
     pub user_agent: Option<VarStr>,
-    /// The node's best block height.
+    /// The node's block height.
     pub start_height: Option<i32>,
     /// The number of services supported by the node.
     pub services: Option<u64>,

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -159,6 +159,7 @@ impl Reading for Crawler {
                     known_node.protocol_version = Some(ver.version);
                     known_node.user_agent = Some(ver.user_agent);
                     known_node.services = Some(ver.services);
+                    known_node.start_height = Some(ver.start_height);
                 }
 
                 let _ = self.unicast(source, Message::Verack)?.await;


### PR DESCRIPTION
Allow recognize type of network for each node. Currently it allows to check if node is from real ZCash network or from any other.

Classification is based on three factors:
start_height - this MUST match
port
agent string

If either port or agent string would not match node still can be considered as ZCash node as long as start_height matches. The only exception is when agent string identifies node as version 6 (which is other network than ZCash) - that is blocker and even when two other conditions are met, node wouldn't be considered as valid ZCash node.