### PR TITLE
chore: ignore dev tests in check

### DIFF
--- a/.github/workflows/check-and-lint.yml
+++ b/.github/workflows/check-and-lint.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         steps:
           - name: test
-            run: cargo test -- --test-threads=1 --ignored
+            run: cargo test -- --test-threads=1 --ignored --skip dev
           - name: check-crawler
             run: cargo check --features=crawler
     steps:


### PR DESCRIPTION
Since development tests are not meant to be run without a compiled node instance, we have to ignore them in `check-and-lint` by ~~explicitly testing under the namespace `protocol::payload`~~ appending `--skip dev` to the command.