### PR TITLE
More info in the logs about the new connection during handshake

### DIFF
--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -219,6 +219,13 @@ impl SyntheticNode {
         Ok(())
     }
 
+    /// Disconnects from the target address.
+    ///
+    /// Returns `true` if an actual disconnect took place.
+    pub async fn disconnect(&self, target: SocketAddr) -> bool {
+        self.inner_node.node().disconnect(target).await
+    }
+
     /// Indicates if the `addr` is registered as a connected peer.
     pub fn is_connected(&self, addr: SocketAddr) -> bool {
         self.inner_node.node().is_connected(addr)


### PR DESCRIPTION
```
    chore: log connection info during the handshake
    
    We should be able to see more info in the logs regarding our new
    connection.
```

A second and an extra commit which I needed for some local tests:
```
    feat(synth_node): add disconnect function
```