### PR TITLE
feat: crawler waits for addr message for given timeout

### DIFF
--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -21,12 +21,13 @@ use ziggurat_core_crawler::summary::NetworkSummary;
 
 use crate::{
     metrics::{NetworkMetrics, ZCASH_P2P_DEFAULT_PORT},
-    network::KnownNode,
-    protocol::{Crawler, MAIN_LOOP_INTERVAL, NUM_CONN_ATTEMPTS_PERIODIC, RECONNECT_INTERVAL},
+    network::{KnownNode, NodeState},
+    protocol::{
+        Crawler, MAIN_LOOP_INTERVAL, MAX_WAIT_FOR_ADDR, NUM_CONN_ATTEMPTS_PERIODIC,
+        RECONNECT_INTERVAL,
+    },
     rpc::{initialize_rpc_server, RpcContext},
 };
-use crate::network::NodeState;
-use crate::protocol::MAX_WAIT_FOR_ADDR;
 
 mod metrics;
 mod network;
@@ -186,7 +187,9 @@ async fn main() {
             {
                 warn!(parent: crawler.node().span(), "disconnecting from node {} because it didn't send us proper addr message", addr);
                 crawler.node().disconnect(addr).await;
-                crawler.known_network.set_node_state(addr, NodeState::Disconnected);
+                crawler
+                    .known_network
+                    .set_node_state(addr, NodeState::Disconnected);
             }
 
             for (addr, _) in crawler

--- a/src/tools/crawler/network.rs
+++ b/src/tools/crawler/network.rs
@@ -12,7 +12,7 @@ use ziggurat_core_crawler::connection::KnownConnection;
 pub const LAST_SEEN_CUTOFF: u64 = 10 * 60;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub enum NodeState {
+pub enum ConnectionState {
     /// The node is not connected.
     #[default]
     Disconnected,
@@ -39,7 +39,7 @@ pub struct KnownNode {
     /// The number of subsequent connection errors.
     pub connection_failures: u8,
     /// The node's state.
-    pub state: NodeState,
+    pub state: ConnectionState,
 }
 
 /// The list of nodes and connections the crawler is aware of.
@@ -65,8 +65,8 @@ impl KnownNetwork {
         });
     }
 
-    /// Sets the node's state.
-    pub fn set_node_state(&self, addr: SocketAddr, state: NodeState) {
+    /// Sets the node's connection state.
+    pub fn set_node_state(&self, addr: SocketAddr, state: ConnectionState) {
         if let Some(node) = self.nodes.write().get_mut(&addr) {
             node.state = state;
         }

--- a/src/tools/crawler/network.rs
+++ b/src/tools/crawler/network.rs
@@ -11,6 +11,15 @@ use ziggurat_core_crawler::connection::KnownConnection;
 /// The elapsed time before a connection should be regarded as inactive.
 pub const LAST_SEEN_CUTOFF: u64 = 10 * 60;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub enum NodeState {
+    /// The node is not connected.
+    #[default]
+    Disconnected,
+    /// The node is connected.
+    Connected,
+}
+
 /// A node encountered in the network or obtained from one of the peers.
 #[derive(Debug, Default, Clone)]
 pub struct KnownNode {
@@ -29,6 +38,8 @@ pub struct KnownNode {
     pub services: Option<u64>,
     /// The number of subsequent connection errors.
     pub connection_failures: u8,
+    /// The node's state.
+    pub state: NodeState,
 }
 
 /// The list of nodes and connections the crawler is aware of.
@@ -52,6 +63,13 @@ impl KnownNetwork {
         listening_addrs.iter().for_each(|addr| {
             nodes.entry(*addr).or_default();
         });
+    }
+
+    /// Sets the node's state.
+    pub fn set_node_state(&self, addr: SocketAddr, state: NodeState) {
+        if let Some(node) = self.nodes.write().get_mut(&addr) {
+            node.state = state;
+        }
     }
 
     /// Returns a snapshot of the known connections.

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -14,9 +14,9 @@ use ziggurat::{
     },
     tools::synthetic_node::MessageCodec,
 };
-use crate::network::NodeState;
 
 use super::network::KnownNetwork;
+use crate::network::NodeState;
 
 pub const NUM_CONN_ATTEMPTS_PERIODIC: usize = 500;
 pub const MAX_CONCURRENT_CONNECTIONS: u16 = 1200;
@@ -149,7 +149,8 @@ impl Reading for Crawler {
                 // condition preventing address comparision to source when len would be 0).
                 if len > 1 || (len == 1 && addr.addrs[0].addr != source) {
                     self.node().disconnect(source).await;
-                    self.known_network.set_node_state(source, NodeState::Disconnected);
+                    self.known_network
+                        .set_node_state(source, NodeState::Disconnected);
                 }
             }
             Message::Ping(nonce) => {

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -16,13 +16,13 @@ use ziggurat::{
 };
 
 use super::network::KnownNetwork;
-use crate::network::NodeState;
+use crate::network::ConnectionState;
 
 pub const NUM_CONN_ATTEMPTS_PERIODIC: usize = 500;
 pub const MAX_CONCURRENT_CONNECTIONS: u16 = 1200;
-pub const MAIN_LOOP_INTERVAL: u64 = 20;
-pub const RECONNECT_INTERVAL: u64 = 5 * 60;
-pub const MAX_WAIT_FOR_ADDR: u64 = 3 * 60;
+pub const MAIN_LOOP_INTERVAL_SECS: u64 = 20;
+pub const RECONNECT_INTERVAL_SECS: u64 = 5 * 60;
+pub const MAX_WAIT_FOR_ADDR_SECS: u64 = 3 * 60;
 
 /// Represents the crawler together with network metrics it has collected.
 #[derive(Clone)]
@@ -69,7 +69,7 @@ impl Crawler {
                     known_node.connection_failures = 0;
                     known_node.last_connected = Some(timestamp);
                     known_node.handshake_time = Some(timestamp.elapsed());
-                    known_node.state = NodeState::Connected;
+                    known_node.state = ConnectionState::Connected;
                 }
                 Err(_) => {
                     trace!(parent: self.node().span(), "failed to connect to {}", addr);
@@ -150,7 +150,7 @@ impl Reading for Crawler {
                 if len > 1 || (len == 1 && addr.addrs[0].addr != source) {
                     self.node().disconnect(source).await;
                     self.known_network
-                        .set_node_state(source, NodeState::Disconnected);
+                        .set_node_state(source, ConnectionState::Disconnected);
                 }
             }
             Message::Ping(nonce) => {

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -19,8 +19,8 @@ use crate::network::NodeState;
 use super::network::KnownNetwork;
 
 pub const NUM_CONN_ATTEMPTS_PERIODIC: usize = 500;
-pub const MAX_CONCURRENT_CONNECTIONS: u16 = 1000;
-pub const MAIN_LOOP_INTERVAL: u64 = 5;
+pub const MAX_CONCURRENT_CONNECTIONS: u16 = 1200;
+pub const MAIN_LOOP_INTERVAL: u64 = 20;
 pub const RECONNECT_INTERVAL: u64 = 5 * 60;
 pub const MAX_WAIT_FOR_ADDR: u64 = 3 * 60;
 


### PR DESCRIPTION
This feature changes crawler behavior - till this commit, crawler connected to the peer, grab first addr message and instantly disconnected. Now, crawler waits for the first addr message that contains more than one address OR addr message with one address but different from the peer source address.

Waiting for addr message implies that crawler has to manage connected nodes - it's done using additional field in known_network structure. Connections are managed from the main loop - old connected nodes are disconnected after specified timeout (180 s).

Waiting for addr message makes crawler work slower. There can be observed more "waves" where connections are made and then, some waves where crawler prints it cannot make new connections due to connection limit reached. However, those hosts should be crawler too as they are added to known addresses and not marked as beeing visited.

To avoid error messages about too many connections, connection limit has been slightly increased. Main loop interval has been increased as now crawler works a bit slower, waiting for second addr message for each connection.