### PR TITLE
ci(crawler): use dns-seed instead of compiling local node

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,8 +16,8 @@ The test suite workflows can be broken down into the following 5 steps:
 ## Network Crawler
 
 The network crawler workflow can be broken down into the following 4 steps:
-1. Build a `zcashd` node from source.
-2. Run the crawler binary with the compiled node as the network entry point.
+1. (Optional) Build a `zcashd` node from source.
+2. Run the crawler binary, fetching node addresses via DNS or connecting to the network through a local node.
 3. Wait 30 minutes, then query metrics via RPC and kill the running crawler.
 4. Process the results.
 

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -5,37 +5,13 @@ on:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
-  call-build-zcashd-workflow:
-    uses: runziggurat/zcash/.github/workflows/build-zcashd.yml@main
-
   crawl-network:
     runs-on: ubuntu-latest
-    needs: [ call-build-zcashd-workflow ]
     steps:
       - uses: actions/checkout@v3
-      - run: rustup toolchain install stable --profile minimal
-      - uses: actions/download-artifact@v3
-        with:
-          name: zcashd-fetch-params
-          path: ./zcash
-      - uses: actions/download-artifact@v3
-        with:
-          name: zcashd-executable
-          path: ./zcash
-      - name: Create ~/.zcash/zcash.conf
-        run: |
-          mkdir ~/.zcash/
-          touch ~/.zcash/zcash.conf
-          echo bind=127.0.0.1:12345 > ~/.zcash/zcash.conf
-      - name: Fetch zcashd params
-        run: |
-          chmod +x zcash/fetch-params.sh
-          ./zcash/fetch-params.sh
       - name: Begin crawling
         run: |
-          chmod +x zcash/zcashd
-          ./zcash/zcashd &
-          cargo run --release --features crawler --bin crawler -- --seed-addrs 127.0.0.1:12345 --rpc-addr 127.0.0.1:54321 &
+          cargo run --release --features crawler --bin crawler -- --dns-seed "dnsseed.z.cash" "dnsseed.str4d.xyz" "mainnet.seeder.zfnd.org" "mainnet.is.yolo.money" --rpc-addr 127.0.0.1:54321 &
           # After 30 min, query rpc and send SIGINT.
           sleep 30m
           curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > latest.json


### PR DESCRIPTION
- Crawler now enters the network via nodes fetched from DNS instead of compiling a local node and entering that way.