### PR TITLE
ref: use seed-addrs for both standalone ips and dns

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Begin crawling
         run: |
-          cargo run --release --features crawler --bin crawler -- --dns-seed "dnsseed.z.cash" "dnsseed.str4d.xyz" "mainnet.seeder.zfnd.org" "mainnet.is.yolo.money" --rpc-addr 127.0.0.1:54321 &
+          cargo run --release --features crawler --bin crawler -- --seed-addrs "dnsseed.z.cash" "dnsseed.str4d.xyz" "mainnet.seeder.zfnd.org" "mainnet.is.yolo.money" --rpc-addr 127.0.0.1:54321 &
           # After 30 min, query rpc and send SIGINT.
           sleep 30m
           curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > latest.json

--- a/src/tools/crawler/README.md
+++ b/src/tools/crawler/README.md
@@ -12,10 +12,7 @@ $ cargo run --release --features crawler --bin crawler -- --help
 OPTIONS:
     -c, --crawl-interval <CRAWL_INTERVAL>
             The main crawling loop interval in seconds [default: 5]
-            
-    -d, --dns-seed <DNS_SEED_ADDRS>...
-            DNS seeder addresses to use (can be used multiple times)
-            
+
     -h, --help
             Print help information
 
@@ -23,7 +20,7 @@ OPTIONS:
             If present, start an RPC server at the specified address
 
     -s, --seed-addrs <SEED_ADDRS>...
-            The initial addresses to connect to (can be used multiple times)
+            A list of initial standalone IP addresses and/or DNS servers to connect to
 
     -V, --version
             Print version information
@@ -78,4 +75,3 @@ A sample of the data we collect and metrics we compute (obtained via RPC):
   "avg_degree_centrality": 274
 }
 ```
-


### PR DESCRIPTION
- IP addresses/DNS servers are now given with the same CLI argument, `--seed-addrs`.
- Crawler will first try to parse an argument as a `SocketAddr`, if that fails it will try a DNS lookup instead.
- Also included are accompanying docs and workflow changes.