### PR TITLE
feat: alert message type

### DIFF
--- a/src/protocol/message/constants.rs
+++ b/src/protocol/message/constants.rs
@@ -49,3 +49,4 @@ pub const REJECT_COMMAND: [u8; COMMAND_LEN] = *b"reject\0\0\0\0\0\0";
 pub const FILTERLOAD_COMMAND: [u8; COMMAND_LEN] = *b"filterload\0\0";
 pub const FILTERADD_COMMAND: [u8; COMMAND_LEN] = *b"filteradd\0\0\0";
 pub const FILTERCLEAR_COMMAND: [u8; COMMAND_LEN] = *b"filterclear\0";
+pub const ALERT_COMMAND: [u8; COMMAND_LEN] = *b"alert\0\0\0\0\0\0\0";


### PR DESCRIPTION
Synth node may sometimes fail because of alert messages sent by ancient real nodes. Since alert messages have been deprecated since long ago, we ignore them.