### PR TITLE
 feat: support for WtxMxg type in InvHash 

### DIFF
--- a/src/protocol/payload/block.rs
+++ b/src/protocol/payload/block.rs
@@ -6,9 +6,7 @@ use bytes::{Buf, BufMut};
 use sha2::Digest;
 
 use crate::protocol::payload::{
-    codec::Codec,
-    inv::{InvHash, ObjectKind},
-    read_n_bytes, Hash, ProtocolVersion, Tx, VarInt,
+    codec::Codec, inv::InvHash, read_n_bytes, Hash, ProtocolVersion, Tx, VarInt,
 };
 
 /// The locator hash object, used to communicate chain state.
@@ -163,7 +161,7 @@ impl Block {
 
     /// Convenience function which creates the [`InvHash`] for this block.
     pub fn inv_hash(&self) -> InvHash {
-        InvHash::new(ObjectKind::Block, self.double_sha256().unwrap())
+        InvHash::Block(self.double_sha256().unwrap())
     }
 }
 

--- a/src/protocol/payload/inv.rs
+++ b/src/protocol/payload/inv.rs
@@ -36,61 +36,44 @@ impl Codec for Inv {
     }
 }
 
-/// An inventory hash.
+/// An inventory hash which refers to some advertised or requested data.
+///
+/// Bitcoin calls this an "inventory vector" but it is just a typed hash, not a
+/// container, so we do not use that term to avoid confusion with `Vec<T>`.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct InvHash {
-    /// The object type linked to this inventory.
-    kind: ObjectKind,
-    /// The hash of the object.
-    hash: Hash,
+pub enum InvHash {
+    /// Any data of this kind may be ignored.
+    Error,
+    /// The hash is that of a transaction.
+    Tx(Hash),
+    /// The hash is that of a block.
+    Block(Hash),
+    /// The hash is that of a block header.
+    FilteredBlock(Hash),
 }
 
 impl InvHash {
-    /// Returns a new `InvHash` instance.
-    pub fn new(kind: ObjectKind, hash: Hash) -> Self {
-        Self { kind, hash }
+    /// Returns the serialized Zcash network protocol code for the current variant.
+    fn code(&self) -> u32 {
+        match self {
+            Self::Error => 0,
+            Self::Tx(_) => 1,
+            Self::Block(_) => 2,
+            Self::FilteredBlock(_) => 3,
+        }
     }
 }
 
 impl Codec for InvHash {
     fn encode<B: BufMut>(&self, buffer: &mut B) -> io::Result<()> {
-        self.kind.encode(buffer)?;
-        self.hash.encode(buffer)?;
+        buffer.put_u32_le(self.code());
 
-        Ok(())
-    }
-
-    fn decode<B: Buf>(bytes: &mut B) -> io::Result<Self> {
-        let kind = ObjectKind::decode(bytes)?;
-        let hash = Hash::decode(bytes)?;
-
-        Ok(Self { kind, hash })
-    }
-}
-
-/// The inventory object kind.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum ObjectKind {
-    /// Any data of this kind may be ignored.
-    Error,
-    /// The hash is that of a transaction.
-    Tx,
-    /// The hash is that of a block.
-    Block,
-    /// The hash is that of a block header.
-    FilteredBlock,
-}
-
-impl Codec for ObjectKind {
-    fn encode<B: BufMut>(&self, buffer: &mut B) -> io::Result<()> {
-        let value: u32 = match self {
-            Self::Error => 0,
-            Self::Tx => 1,
-            Self::Block => 2,
-            Self::FilteredBlock => 3,
-        };
-
-        buffer.put_u32_le(value);
+        match self {
+            Self::Tx(hash) | Self::Block(hash) | Self::FilteredBlock(hash) => {
+                hash.encode(buffer)?;
+            }
+            _ => (),
+        }
 
         Ok(())
     }
@@ -100,13 +83,13 @@ impl Codec for ObjectKind {
 
         let kind = match value {
             0 => Self::Error,
-            1 => Self::Tx,
-            2 => Self::Block,
-            3 => Self::FilteredBlock,
+            1 => Self::Tx(Hash::decode(bytes)?),
+            2 => Self::Block(Hash::decode(bytes)?),
+            3 => Self::FilteredBlock(Hash::decode(bytes)?),
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    "ObjectKind is not known",
+                    format!("unknown inv hash value type: {value}"),
                 ))
             }
         };

--- a/src/protocol/payload/tx.rs
+++ b/src/protocol/payload/tx.rs
@@ -5,11 +5,7 @@ use std::{convert::TryInto, io};
 use bytes::{Buf, BufMut};
 use sha2::Digest;
 
-use crate::protocol::payload::{
-    codec::Codec,
-    inv::{InvHash, ObjectKind},
-    read_n_bytes, Hash, VarInt,
-};
+use crate::protocol::payload::{codec::Codec, inv::InvHash, read_n_bytes, Hash, VarInt};
 
 /// A Zcash transaction ([spec](https://zips.z.cash/protocol/canopy.pdf#txnencodingandconsensus)).
 ///
@@ -40,7 +36,7 @@ impl Tx {
 
     /// Convenience function which creates the [`InvHash`] for this `Tx`.
     pub fn inv_hash(&self) -> InvHash {
-        InvHash::new(ObjectKind::Tx, self.double_sha256().unwrap())
+        InvHash::Tx(self.double_sha256().unwrap())
     }
 }
 

--- a/src/tests/conformance/invalid_message/disconnect.rs
+++ b/src/tests/conformance/invalid_message/disconnect.rs
@@ -8,8 +8,8 @@
 //! [`Inv`](Message::Inv) containing both [`Block`][inv_block] and [`Tx`][inv_tx] types in [`InvHash`][inv_hash].
 //! [`Addr`](Message::Addr) containing a [`NetworkAddr`][net_addr] *without* a  timestamp.
 //!
-//! [inv_block]: crate::protocol::payload::inv::ObjectKind::Block
-//! [inv_tx]: crate::protocol::payload::inv::ObjectKind::Tx
+//! [inv_block]: crate::protocol::payload::inv::InvHash::Block
+//! [inv_tx]: crate::protocol::payload::inv::InvHash::Tx
 //! [inv_hash]: crate::protocol::payload::inv::InvHash
 //! [net_addr]: crate::protocol::payload::addr::NetworkAddr
 //!

--- a/src/tests/conformance/query/get_data.rs
+++ b/src/tests/conformance/query/get_data.rs
@@ -9,10 +9,7 @@
 use crate::{
     protocol::{
         message::Message,
-        payload::{
-            inv::{InvHash, ObjectKind},
-            Hash, Inv,
-        },
+        payload::{inv::InvHash, Hash, Inv},
     },
     tests::conformance::query::{run_test_query, SEED_BLOCKS},
 };
@@ -57,7 +54,7 @@ mod single_block {
     #[allow(non_snake_case)]
     async fn c018_t4_GET_DATA_non_existent() {
         // zcashd: fail (ignores non-existent block)
-        let inv = Inv::new(vec![InvHash::new(ObjectKind::Block, Hash::new([17; 32]))]);
+        let inv = Inv::new(vec![InvHash::Block(Hash::new([17; 32]))]);
         let query = Message::GetData(inv.clone());
         let expected = vec![Message::NotFound(inv)];
         let response = run_test_query(query).await.unwrap();
@@ -118,9 +115,9 @@ mod multiple_blocks {
     async fn c018_t8_GET_DATA_non_existent_blocks() {
         // zcashd: fails (ignores non-existent blocks).
         let inv = Inv::new(vec![
-            InvHash::new(ObjectKind::Block, Hash::new([17; 32])),
-            InvHash::new(ObjectKind::Block, Hash::new([211; 32])),
-            InvHash::new(ObjectKind::Block, Hash::new([74; 32])),
+            InvHash::Block(Hash::new([17; 32])),
+            InvHash::Block(Hash::new([211; 32])),
+            InvHash::Block(Hash::new([74; 32])),
         ]);
 
         let query = Message::GetData(inv.clone());
@@ -144,9 +141,9 @@ mod multiple_blocks {
         // zcashd: fails (ignores non-existent blocks).
 
         let non_existent_inv = vec![
-            InvHash::new(ObjectKind::Block, Hash::new([17; 32])),
-            InvHash::new(ObjectKind::Block, Hash::new([211; 32])),
-            InvHash::new(ObjectKind::Block, Hash::new([74; 32])),
+            InvHash::Block(Hash::new([17; 32])),
+            InvHash::Block(Hash::new([211; 32])),
+            InvHash::Block(Hash::new([74; 32])),
         ];
         let blocks = SEED_BLOCKS
             .iter()


### PR DESCRIPTION
Ensures that our synth node binary (or a crawler) won't die within a few seconds after performing a handshake with zebrad