### PR TITLE
ci: run crawler on self-hosted machine

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -1,12 +1,13 @@
 name: crawler
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
   crawl-network:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - name: Begin crawling


### PR DESCRIPTION
Also adds `workflow_dipsatch` so we can manually trigger the workflow.