### PR TITLE
ci: supply secrets to `diff-with-latest`

### DIFF
--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -47,7 +47,7 @@ jobs:
         continue-on-error: true
         run: |
           rm ./ziggurat/*.d
-          mv ./ziggurat/ziggurat-* ziggurat_test
+          mv ./ziggurat/ziggurat_zcash-* ziggurat_test
           chmod +x ziggurat_test
           chmod +x zcash/zcashd
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > latest.jsonl

--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -69,3 +69,8 @@ jobs:
   call-diff-with-previous-workflow:
     needs: [ test-zcashd ]
     uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
+    with:
+      name: zcashd
+      repository: zcash
+    secrets:
+      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -73,3 +73,8 @@ jobs:
   call-diff-with-previous-workflow:
     needs: [ test-zebra ]
     uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
+    with:
+      name: zebra
+      repository: zcash
+    secrets:
+      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -52,7 +52,7 @@ jobs:
         continue-on-error: true
         run: |
           rm ./ziggurat/*.d
-          mv ./ziggurat/ziggurat-* ziggurat_test
+          mv ./ziggurat/ziggurat_zcash-* ziggurat_test
           chmod +x ziggurat_test
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > latest.jsonl
           cat latest.jsonl


### PR DESCRIPTION
- Supply secrets to `diff-with-latest` step so it can download the previous result.
- Updates build artifact name to be correct.