### PR TITLE
chore: wait for Version message before sending GetAddr

### DIFF
--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -168,9 +168,8 @@ async fn main() {
                 .write()
                 .insert(addr, KnownNode::default());
 
-            // Don't care about the result - errors are logged inside connect() and
-            // successful connections do not involve any further actions as sending
-            // GetAddr message was moved to process_message in protocol.rs.
+            // Once the Version message is received in the process_message function,
+            // GetAddr will be requested from the peer
             let _ = crawler_clone.connect(addr).await;
         });
     }
@@ -232,9 +231,8 @@ async fn main() {
                 if crawler.should_connect(addr) {
                     let crawler_clone = crawler.clone();
                     tokio::spawn(async move {
-                        // Don't care about the result - errors are logged inside connect() and
-                        // successful connections do not involve any further actions as sending
-                        // GetAddr message was moved to process_message in protocol.rs.
+                        // Once the Version message is received in the process_message function,
+                        // GetAddr will be requested from the peer
                         let _ = crawler_clone.connect(addr).await;
                     });
                 }

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -186,11 +186,11 @@ impl Reading for Crawler {
                 // In fact, this part should be done during the handshake but it would increase
                 // handshake time and there are some nodes that do not send version message
                 // quickly (we know that zebra can delay sending version message for over 30 seconds).
-                // Sending GetAddr before receiving version results in dropping this message by
-                // the remote peer so we're stuck waiting for reply that will never come that's why we
-                // need to wait for remote version message.
-                // Sending GetAddr message was moved to this place to and it's not sent anymore
-                // directly from main module.
+                // Sending GetAddr before receiving the version results in dropping this message by
+                // the remote peer, so we're stuck waiting for a reply that will never come that's why we
+                // need to wait for the remote version message response.
+                // Extra background: Sending GetAddr message was moved to this place,
+                // and it's not sent anymore directly from the main module.
                 let _ = self.unicast(source, Message::GetAddr)?.await;
             }
             _ => {}


### PR DESCRIPTION
During tests some of the peers have been observed to have delays (massive!) in sending first Version message.
Till that commit crawler:
1) had degenerated handshake procedure - it was waiting only for crawler to send version and returned success;
2) had hardcoded 1 sec sleep after successfull connect() and after that it just sent GetAddr message.

The above resulted in situations, where GetAddr was sent before the remote party sent crawler version message. It leads to dropping GetAddr message as the protocol standard says that there can be no other communication before exchanging Version messages.

This commit removes hardcodes and make crawler fit into protocol standard. Now GetAddr messages are sent only after crawler receives Version message from the remote party. That allows to wait even up to crawler connection limit (120 secs for single connection).