### PR TITLE
ci: diff before uploading new results

### DIFF
--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -57,18 +57,18 @@ jobs:
           name: latest-result
           path: latest.jsonl
 
-  call-process-results-workflow:
+  call-diff-with-previous-workflow:
     needs: [ test-zcashd ]
-    uses: runziggurat/ziggurat-core/.github/workflows/process-results.yml@main
+    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
     with:
       name: zcashd
       repository: zcash
     secrets:
       gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
 
-  call-diff-with-previous-workflow:
-    needs: [ test-zcashd ]
-    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
+  call-process-results-workflow:
+    needs: [ call-diff-with-previous-workflow ]
+    uses: runziggurat/ziggurat-core/.github/workflows/process-results.yml@main
     with:
       name: zcashd
       repository: zcash

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-zebra, call-build-ziggurat-workflow ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: rustup toolchain install nightly --profile minimal
@@ -61,18 +61,18 @@ jobs:
           name: latest-result
           path: latest.jsonl
 
-  call-process-results-workflow:
+  call-diff-with-previous-workflow:
     needs: [ test-zebra ]
-    uses: runziggurat/ziggurat-core/.github/workflows/process-results.yml@main
+    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
     with:
       name: zebra
       repository: zcash
     secrets:
       gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
 
-  call-diff-with-previous-workflow:
-    needs: [ test-zebra ]
-    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
+  call-process-results-workflow:
+    needs: [ call-diff-with-previous-workflow ]
+    uses: runziggurat/ziggurat-core/.github/workflows/process-results.yml@main
     with:
       name: zebra
       repository: zcash


### PR DESCRIPTION
Sometimes the workflows run into race conditions where the behavior is different depending on if the latest result gets uploaded before it gets downloaded in another step. This PR makes sure they run consecutively instead.