### PR TITLE
ci: remove `diff-with-previous` step

### DIFF
--- a/.github/workflows/zcashd-nightly.yml
+++ b/.github/workflows/zcashd-nightly.yml
@@ -65,12 +65,3 @@ jobs:
       repository: zcash
     secrets:
       gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
-
-  call-diff-with-previous-workflow:
-    needs: [ test-zcashd ]
-    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
-    with:
-      name: zcashd
-      repository: zcash
-    secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/zebra.yml
+++ b/.github/workflows/zebra.yml
@@ -69,12 +69,3 @@ jobs:
       repository: zcash
     secrets:
       gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
-
-  call-diff-with-previous-workflow:
-    needs: [ test-zebra ]
-    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
-    with:
-      name: zebra
-      repository: zcash
-    secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
(Closes #240)
Diffing is handled easier in the GUI, thus we remove this step from the workflows.