### PR TITLE
refactor(synth_node_bin): support multiple actions

### DIFF
--- a/synth_node_bin/Cargo.lock
+++ b/synth_node_bin/Cargo.lock
@@ -1298,6 +1298,7 @@ name = "synth_node_bin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "rand",
  "tokio",

--- a/synth_node_bin/Cargo.toml
+++ b/synth_node_bin/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 clap = { version = "4.2", features = ["derive"] }
 rand = "0.8"
 tokio = { version = "1", features = ["time"] }

--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -1,0 +1,56 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use ziggurat_zcash::tools::synthetic_node::SyntheticNode;
+
+mod send_get_addr_and_forever_sleep;
+
+/// Defines properties of any action for a synth node binary.
+///
+/// It simplifies adding new actions and allows to separate different actions with modules.
+#[async_trait::async_trait]
+trait SynthNodeAction {
+    /// Action description.
+    ///
+    /// It can be displayed during the runtime.
+    fn info(&self) -> &str;
+
+    /// Defines the core action functionality.
+    ///
+    /// All the program logic happens here.
+    async fn run(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()>;
+}
+
+/// List of available actions.
+pub enum ActionType {
+    SendGetAddrAndForeverSleep,
+}
+
+/// Action handler.
+pub struct ActionHandler {
+    /// Internal action.
+    action: Box<dyn SynthNodeAction>,
+}
+
+impl ActionHandler {
+    /// Creates a new [`ActionHandler`] for a given [`ActionType`].
+    pub fn new(action_type: ActionType) -> Self {
+        Self {
+            action: Box::new(match action_type {
+                ActionType::SendGetAddrAndForeverSleep => {
+                    send_get_addr_and_forever_sleep::Action {}
+                }
+            }),
+        }
+    }
+
+    /// Runs the underlying action.
+    pub async fn execute(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()> {
+        println!(
+            "Running a synth node which performs the following:\n\t{}",
+            self.action.info()
+        );
+
+        self.action.run(synth_node, addr).await
+    }
+}

--- a/synth_node_bin/src/action/send_get_addr_and_forever_sleep.rs
+++ b/synth_node_bin/src/action/send_get_addr_and_forever_sleep.rs
@@ -1,0 +1,36 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use tokio::time::{sleep, Duration};
+use ziggurat_zcash::{protocol::message::Message, tools::synthetic_node::SyntheticNode};
+
+use super::SynthNodeAction;
+
+pub struct Action;
+
+#[async_trait::async_trait]
+impl SynthNodeAction for Action {
+    fn info(&self) -> &str {
+        "request an GetAddr and then sleeps forever"
+    }
+
+    #[allow(unused_variables)]
+    async fn run(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()> {
+        println!("Synthetic node performs an action.");
+
+        // Custom code goes here, example:
+        sleep(Duration::from_millis(5000)).await;
+
+        let msg = Message::GetAddr;
+        tracing::info!("unicast {msg:?}\n");
+        if synth_node.unicast(addr, msg.clone()).is_err() {
+            tracing::warn!("failed to send {msg:?}\n");
+            anyhow::bail!("connection closed");
+        }
+
+        loop {
+            let (_, msg) = synth_node.try_recv_message().await?;
+            tracing::info!("message received: {msg:?}");
+        }
+    }
+}


### PR DESCRIPTION
A synth node binary should have an easy way to add new actions. This implementation provides action plugin support so that all different actions can be added under different modules under the `src/action/` directory.