### PR TITLE
feat(synth_node_bin): add advanced SN for s001

### DIFF
--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -1,6 +1,7 @@
 //! A lightweight node implementation to be used as peers in tests.
 
 use std::{
+    collections::HashMap,
     io::{self, Error, ErrorKind},
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
@@ -11,7 +12,7 @@ use bytes::{BufMut, BytesMut};
 use futures_util::{sink::SinkExt, TryStreamExt};
 use pea2pea::{
     protocols::{Handshake, Reading, Writing},
-    Config as NodeConfig, Connection, ConnectionSide, Node, Pea2Pea,
+    Config as NodeConfig, Connection, ConnectionInfo, ConnectionSide, Node, Pea2Pea,
 };
 use tokio::{
     sync::mpsc::{self, Receiver, Sender},
@@ -260,9 +261,14 @@ impl SyntheticNode {
         self.inner_node.node().num_connected()
     }
 
-    /// Returns the list of active connections for this node. Should be preferred over [`known_peers`] when querying active connections.
+    /// Returns the list of active connections for this node.
     pub fn connected_peers(&self) -> Vec<SocketAddr> {
         self.inner_node.node().connected_addrs()
+    }
+
+    /// Returns the infos for active connections for this node.
+    pub fn connected_peer_infos(&self) -> HashMap<SocketAddr, ConnectionInfo> {
+        self.inner_node.node().connection_infos()
     }
 
     /// Waits until the node has at least one connection, and returns its SocketAddr.

--- a/synth_node_bin/src/action/advanced_sn_for_s001.rs
+++ b/synth_node_bin/src/action/advanced_sn_for_s001.rs
@@ -1,0 +1,183 @@
+use std::{net::SocketAddr, str::FromStr};
+
+use anyhow::Result;
+use tokio::time::{interval, sleep, Duration};
+use ziggurat_zcash::{
+    protocol::{
+        message::Message,
+        payload::{addr::NetworkAddr, Addr, Nonce},
+    },
+    tools::{
+        message_filter::{Filter, MessageFilter},
+        synthetic_node::SyntheticNode,
+    },
+};
+
+use super::{ActionCfg, SynthNodeAction};
+
+// Configurable status printout interval.
+const DBG_INFO_LOG_INTERVAL_SEC: Duration = Duration::from_secs(10);
+const BROADCAST_INTERVAL_SEC: Duration = Duration::from_secs(120);
+
+pub(super) struct Action;
+
+pub(super) fn action() -> Box<dyn SynthNodeAction> {
+    Box::new(Action {})
+}
+
+#[async_trait::async_trait]
+impl SynthNodeAction for Action {
+    fn info(&self) -> &str {
+        "an advanced SN node created for RT-S001 which can do the following
+           - listens for inbound connections and prints the connection status periodically
+           - periodically requests and sends Ping/GetAddr/Addr messages to all peers"
+    }
+
+    fn config(&self) -> ActionCfg {
+        ActionCfg {
+            msg_filter: MessageFilter::with_all_auto_reply().with_getaddr_filter(Filter::Disabled),
+        }
+    }
+
+    #[allow(unused_variables)]
+    async fn run(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()> {
+        // Sleep for three seconds before taking any actions - so the GetHeaders is handled before we
+        // send GetAddr to the zcashd node for our only outbound connection.
+        sleep(Duration::from_secs(3)).await;
+
+        let msg = Message::GetAddr;
+        tracing::info!("unicast {msg:?}\n");
+        if synth_node.unicast(addr, msg.clone()).is_err() {
+            tracing::warn!("failed to send {msg:?}\n");
+            anyhow::bail!("connection closed");
+        }
+
+        let mut dbg_info_interval = interval(DBG_INFO_LOG_INTERVAL_SEC);
+        let mut broadcast_msgs_interval = interval(BROADCAST_INTERVAL_SEC);
+
+        loop {
+            tokio::select! {
+                _ = dbg_info_interval.tick() => {
+                    trace_debug_info(synth_node).await;
+                },
+                _ = broadcast_msgs_interval.tick() => {
+                    let _ = broadcast_periodic_msgs(synth_node);
+                },
+                Ok((src, msg)) = synth_node.try_recv_message() => {
+                    handle_rx_msg(synth_node, src, msg).await?;
+                },
+            }
+        }
+    }
+}
+
+async fn trace_debug_info(synth_node: &SyntheticNode) {
+    let peer_infos = synth_node.connected_peer_infos();
+    let peer_cnt = peer_infos.len();
+
+    let mut log = format!("\nNumber of peers: {peer_cnt}\n");
+
+    // Let's sort by the connection's time value.
+    let mut peer_infos: Vec<_> = peer_infos.iter().collect();
+    peer_infos.sort_by(|a, b| a.1.stats().created().cmp(&b.1.stats().created()));
+
+    for (addr, info) in peer_infos.iter() {
+        let stats = info.stats();
+
+        // Align all possible IP addresses (both v4 and v6) vertically
+        // Using this value, just like the INET6_ADDRSTRLEN constant in Linux, has 46 bytes
+        const MAX_IPV6_ADDR_LEN: usize = 46;
+
+        log.push_str(&format!(
+            "{addr:>ident$}   ({side:?}) seconds: {time:?}\n",
+            addr = addr,
+            ident = MAX_IPV6_ADDR_LEN,
+            side = info.side(),
+            time = stats.created().elapsed()
+        ));
+    }
+
+    tracing::info!("{log}");
+}
+
+fn broadcast_periodic_msgs(synth_node: &mut SyntheticNode) -> Result<()> {
+    if let Err(e) = broadcast_ping_msg(synth_node) {
+        tracing::warn!("failed to broadcast Ping messages: {e}");
+    } else if let Err(e) = broadcast_addr_msg(synth_node) {
+        tracing::warn!("failed to broadcast Addr messages: {e}");
+    } else if let Err(e) = broadcast_get_addr_msg(synth_node) {
+        tracing::warn!("failed to broadcast GetAddr messages: {e}");
+    }
+
+    Ok(())
+}
+
+fn broadcast_ping_msg(synth_node: &mut SyntheticNode) -> Result<()> {
+    let msg = Message::Ping(Nonce::default());
+
+    for addr in synth_node.connected_peers() {
+        if synth_node.unicast(addr, msg.clone()).is_err() {
+            tracing::error!("failed to send {msg:?} to {addr}\n");
+            anyhow::bail!("connection closed");
+        }
+    }
+
+    Ok(())
+}
+
+fn broadcast_get_addr_msg(synth_node: &mut SyntheticNode) -> Result<()> {
+    let msg = Message::GetAddr;
+
+    for addr in synth_node.connected_peers() {
+        if synth_node.unicast(addr, msg.clone()).is_err() {
+            tracing::error!("failed to send {msg:?} to {addr}\n");
+            anyhow::bail!("connection closed");
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_rx_msg(
+    synth_node: &mut SyntheticNode,
+    src: SocketAddr,
+    msg: Message,
+) -> Result<()> {
+    tracing::info!("message received from {src}:\n{msg:?}");
+
+    // We are only handling a GetAddr for now.
+    if msg == Message::GetAddr {
+        unicast_addr_msg(synth_node, src)?;
+    }
+
+    Ok(())
+}
+
+fn unicast_addr_msg(synth_node: &mut SyntheticNode, dst: SocketAddr) -> Result<()> {
+    // These are all our IPs
+    let addrs = vec![
+        // Our zebrad
+        NetworkAddr::new(SocketAddr::from_str("35.210.208.185:8233").unwrap()),
+        // Our zcashd
+        NetworkAddr::new(SocketAddr::from_str("35.205.233.245:8233").unwrap()),
+        // Our synth node
+        NetworkAddr::new(SocketAddr::from_str("35.205.233.245:46313").unwrap()),
+    ];
+    let msg = Message::Addr(Addr::new(addrs));
+
+    tracing::info!("unicast {msg:?}\n");
+    if synth_node.unicast(dst, msg.clone()).is_err() {
+        tracing::warn!("failed to send {msg:?}\n");
+        anyhow::bail!("connection closed");
+    }
+
+    Ok(())
+}
+
+fn broadcast_addr_msg(synth_node: &mut SyntheticNode) -> Result<()> {
+    for addr in synth_node.connected_peers() {
+        unicast_addr_msg(synth_node, addr)?;
+    }
+
+    Ok(())
+}

--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -1,9 +1,10 @@
 use std::net::SocketAddr;
 
 use anyhow::Result;
-use ziggurat_zcash::tools::synthetic_node::SyntheticNode;
+use ziggurat_zcash::tools::{message_filter::MessageFilter, synthetic_node::SyntheticNode};
 
 mod send_get_addr_and_forever_sleep;
+mod advanced_sn_for_s001;
 
 /// Defines properties of any action for a synth node binary.
 ///
@@ -15,6 +16,11 @@ trait SynthNodeAction {
     /// It can be displayed during the runtime.
     fn info(&self) -> &str;
 
+    /// Action configuration.
+    ///
+    /// Allows preconfiguration settings before the action execution starts.
+    fn config(&self) -> ActionCfg;
+
     /// Defines the core action functionality.
     ///
     /// All the program logic happens here.
@@ -22,35 +28,54 @@ trait SynthNodeAction {
 }
 
 /// List of available actions.
+// TODO: Make a command argument to choose action type.
+#[allow(dead_code)]
 pub enum ActionType {
     SendGetAddrAndForeverSleep,
+    AdvancedSnFors001,
+}
+
+/// Action configuration options.
+pub struct ActionCfg {
+    pub msg_filter: MessageFilter,
+}
+
+impl Default for ActionCfg {
+    fn default() -> Self {
+        Self {
+            msg_filter: MessageFilter::with_all_auto_reply(),
+        }
+    }
 }
 
 /// Action handler.
 pub struct ActionHandler {
     /// Internal action.
     action: Box<dyn SynthNodeAction>,
+
+    /// Action startup configuration.
+    pub cfg: ActionCfg,
 }
 
 impl ActionHandler {
     /// Creates a new [`ActionHandler`] for a given [`ActionType`].
     pub fn new(action_type: ActionType) -> Self {
-        Self {
-            action: Box::new(match action_type {
-                ActionType::SendGetAddrAndForeverSleep => {
-                    send_get_addr_and_forever_sleep::Action {}
-                }
-            }),
-        }
+        let action = match action_type {
+            ActionType::SendGetAddrAndForeverSleep => send_get_addr_and_forever_sleep::action(),
+            ActionType::AdvancedSnFors001 => advanced_sn_for_s001::action(),
+        };
+        let cfg = action.config();
+
+        println!(
+            "Running a synth node which performs the following:\n\t{}",
+            action.info()
+        );
+
+        Self { action, cfg }
     }
 
     /// Runs the underlying action.
     pub async fn execute(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()> {
-        println!(
-            "Running a synth node which performs the following:\n\t{}",
-            self.action.info()
-        );
-
         self.action.run(synth_node, addr).await
     }
 }

--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -3,8 +3,8 @@ use std::net::SocketAddr;
 use anyhow::Result;
 use ziggurat_zcash::tools::{message_filter::MessageFilter, synthetic_node::SyntheticNode};
 
-mod send_get_addr_and_forever_sleep;
 mod advanced_sn_for_s001;
+mod send_get_addr_and_forever_sleep;
 
 /// Defines properties of any action for a synth node binary.
 ///
@@ -32,7 +32,13 @@ trait SynthNodeAction {
 #[allow(dead_code)]
 pub enum ActionType {
     SendGetAddrAndForeverSleep,
-    AdvancedSnFors001,
+    // TODO(Rqnsom): Add support for choosing listening address in config and apply it in the main.rs here. Details:
+    // To use this Action, use:
+    //    listener_ip: Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+    //    desired_listening_port: Some(8233),
+    // on lines here:
+    // https://github.com/runziggurat/zcash/blob/8c0985a87a19d2f3c9cfb10b5d3137e144a27928/src/tools/synthetic_node.rs#L149
+    AdvancedSnForS001,
 }
 
 /// Action configuration options.
@@ -62,7 +68,7 @@ impl ActionHandler {
     pub fn new(action_type: ActionType) -> Self {
         let action = match action_type {
             ActionType::SendGetAddrAndForeverSleep => send_get_addr_and_forever_sleep::action(),
-            ActionType::AdvancedSnFors001 => advanced_sn_for_s001::action(),
+            ActionType::AdvancedSnForS001 => advanced_sn_for_s001::action(),
         };
         let cfg = action.config();
 

--- a/synth_node_bin/src/action/send_get_addr_and_forever_sleep.rs
+++ b/synth_node_bin/src/action/send_get_addr_and_forever_sleep.rs
@@ -4,14 +4,22 @@ use anyhow::Result;
 use tokio::time::{sleep, Duration};
 use ziggurat_zcash::{protocol::message::Message, tools::synthetic_node::SyntheticNode};
 
-use super::SynthNodeAction;
+use super::{ActionCfg, SynthNodeAction};
 
-pub struct Action;
+pub(super) struct Action;
+
+pub(super) fn action() -> Box<dyn SynthNodeAction> {
+    Box::new(Action {})
+}
 
 #[async_trait::async_trait]
 impl SynthNodeAction for Action {
     fn info(&self) -> &str {
         "request an GetAddr and then sleeps forever"
+    }
+
+    fn config(&self) -> ActionCfg {
+        ActionCfg::default()
     }
 
     #[allow(unused_variables)]

--- a/synth_node_bin/src/main.rs
+++ b/synth_node_bin/src/main.rs
@@ -81,7 +81,7 @@ async fn run_synth_node(node_addr: SocketAddr) -> Result<()> {
     // Create a synthetic node and enable handshaking.
     let mut synth_node = SyntheticNode::builder()
         .with_full_handshake()
-        .with_all_auto_reply()
+        .with_message_filter(action.cfg.msg_filter.clone())
         .build()
         .await
         .unwrap();


### PR DESCRIPTION
Commits with info about the change:
```
    feat(synth_node_bin): add advanced SN for s001

    A synth_node_bin with this action can:
     - listen for inbound connections and print connection status periodically
     - periodically send GetAddr/Ping/Addr messages to all connected peers
```
```
    feat(synthetic_node): add connected_peer_infos API
```
```
    feat(synth_node_bin): support for action preconfig

    - It should be possible to configure the action settings before the
      action is even started in some cases.
```

There's one more TODO in the code regarding the listening address, which needs to be fed to the synth_node builder - which will be done in a separate PR.