### PR TITLE
chore: tx corrections

### DIFF
--- a/src/protocol/payload/tx.rs
+++ b/src/protocol/payload/tx.rs
@@ -561,7 +561,7 @@ impl Codec for TxV5 {
 
         // Decode output proofs.
         let mut output_proofs_sapling = Vec::new();
-        for _ in 0..spends_sapling.len() {
+        for _ in 0..outputs_sapling.len() {
             output_proofs_sapling.push(read_n_bytes(bytes)?);
         }
 

--- a/src/protocol/payload/tx.rs
+++ b/src/protocol/payload/tx.rs
@@ -149,7 +149,7 @@ pub struct TxV2 {
 
     // Only present if the join_split count > 0.
     join_split_pub_key: Option<[u8; 32]>,
-    join_split_sig: Option<[u8; 32]>,
+    join_split_sig: Option<[u8; 64]>,
 }
 
 impl Codec for TxV2 {
@@ -188,14 +188,14 @@ impl Codec for TxV2 {
         }
 
         let (join_split_pub_key, join_split_sig) = if join_split_count > 0 {
-            if bytes.remaining() < 64 {
+            if bytes.remaining() < 96 {
                 return Err(io::ErrorKind::InvalidData.into());
             }
 
             let mut pub_key = [0u8; 32];
             bytes.copy_to_slice(&mut pub_key);
 
-            let mut sig = [0u8; 32];
+            let mut sig = [0u8; 64];
             bytes.copy_to_slice(&mut sig);
 
             (Some(pub_key), Some(sig))
@@ -230,7 +230,7 @@ pub struct TxV3 {
 
     // Only present if the join_split count > 0.
     join_split_pub_key: Option<[u8; 32]>,
-    join_split_sig: Option<[u8; 32]>,
+    join_split_sig: Option<[u8; 64]>,
 }
 
 impl Codec for TxV3 {
@@ -275,14 +275,14 @@ impl Codec for TxV3 {
         }
 
         let (join_split_pub_key, join_split_sig) = if join_split_count > 0 {
-            if bytes.remaining() < 64 {
+            if bytes.remaining() < 96 {
                 return Err(io::ErrorKind::InvalidData.into());
             }
 
             let mut pub_key = [0u8; 32];
             bytes.copy_to_slice(&mut pub_key);
 
-            let mut sig = [0u8; 32];
+            let mut sig = [0u8; 64];
             bytes.copy_to_slice(&mut sig);
 
             (Some(pub_key), Some(sig))
@@ -323,7 +323,7 @@ pub struct TxV4 {
 
     // Only present if the join_split count > 0.
     join_split_pub_key: Option<[u8; 32]>,
-    join_split_sig: Option<[u8; 32]>,
+    join_split_sig: Option<[u8; 64]>,
 
     // Present if and only if spends_sapling_count + outputs_sapling_count > 0.
     binding_sig_sapling: Option<[u8; 64]>,
@@ -384,14 +384,14 @@ impl Codec for TxV4 {
         }
 
         let (join_split_pub_key, join_split_sig) = if *join_split_count > 0 {
-            if bytes.remaining() < 64 {
+            if bytes.remaining() < 96 {
                 return Err(io::ErrorKind::InvalidData.into());
             }
 
             let mut pub_key = [0u8; 32];
             bytes.copy_to_slice(&mut pub_key);
 
-            let mut sig = [0u8; 32];
+            let mut sig = [0u8; 64];
             bytes.copy_to_slice(&mut sig);
 
             (Some(pub_key), Some(sig))

--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -460,7 +460,7 @@ impl Default for MessageCodec {
                 .length_field_offset(16)
                 .little_endian()
                 .num_skip(0)
-                .max_frame_length(65536) // FIXME
+                .max_frame_length(1048576)
                 .new_codec(),
         }
     }

--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -460,6 +460,8 @@ impl Default for MessageCodec {
                 .length_field_offset(16)
                 .little_endian()
                 .num_skip(0)
+                // The biggest currently observed frame was 627412 bytes long, so taking some reserve
+                // to catch frames up to 1MB.
                 .max_frame_length(1048576)
                 .new_codec(),
         }


### PR DESCRIPTION
Three fixes/refactors correcting our node's behavior when processing `tx` structures.

There are following changes:
1. Change max frame length to 1MB. There has been observed frames bigger than currently set limit.

For example sending request (using getdata message) to obtain informationabout the block:
`[53, 232, 24, 104, 196, 154, 85, 106, 186, 216, 58, 134, 35, 37, 5, 230, 98, 51, 164, 248, 91, 6, 223, 175, 92, 57, 245, 211, 56, 50, 100, 0]`
from testnet will result in a reply (block command) which is 627412 bytes.
Standard defines that length field in MessageStructure is uint32_t so the maximum frame size can be really big.
tokio_util::codec max frame length default value is 8 MB.
Extended max frame length to 1MB to have some space in case of bigger frames (which are rare) and not setting it too big to conserve memory.

2. Take nOutputsSapling instead of nSpendsSapling when checking if there are any vOutputProofsSapling to decode
This fixes probable copy-paste problem where vOutputProofsSapling was checked only when nSpendsSapling field was non-zero, but correctly there should be nOutputsSapling field taken into account. That bug was affecting only tx version 5.

The problem existed when requested (using `getdata`) eg. 
`[53, 185, 21, 200, 203, 93, 148, 170, 30, 17, 139, 94, 234, 131, 222, 186, 105, 19, 19, 79, 214, 165, 40, 199, 229, 8, 28, 166, 104, 106, 39, 0]`
block from testnet.

3. Correct join_split_sig field length for Tx version 1 to 4
According to:
https://zips.z.cash/protocol/protocol.pdf#txnencoding
joinSplitSig field has 64 bytes for tx message version 1 to 4. (version 5 removes joinSplitSig field)

The problem existed when requested (using `getdata`) eg.
`[190, 148, 197, 190, 161, 117, 206, 125, 164, 107, 162, 76, 125, 117, 190, 171, 188, 15, 226, 85, 203, 60, 250, 20, 228, 92, 152, 152, 36, 2, 57, 0]`
block info from testnet.