### PR TITLE
feat(synth_node_bin): add network cfg to ActionCfg 

### DIFF
--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -216,6 +216,12 @@ impl SyntheticNodeBuilder {
         self.message_filter = filter;
         self
     }
+
+    /// Sets the node's [`NodeConfig`].
+    pub fn with_network_config(mut self, config: NodeConfig) -> Self {
+        self.network_config = config;
+        self
+    }
 }
 
 /// Convenient abstraction over a `pea2pea` node.

--- a/synth_node_bin/Cargo.lock
+++ b/synth_node_bin/Cargo.lock
@@ -1300,6 +1300,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "pea2pea",
  "rand",
  "tokio",
  "tracing",

--- a/synth_node_bin/Cargo.toml
+++ b/synth_node_bin/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0"
 async-trait = "0.1"
 clap = { version = "4.2", features = ["derive"] }
+pea2pea = "0.46"
 rand = "0.8"
 tokio = { version = "1", features = ["time"] }
 tracing-subscriber = "0.3"

--- a/synth_node_bin/src/action/advanced_sn_for_s001.rs
+++ b/synth_node_bin/src/action/advanced_sn_for_s001.rs
@@ -1,6 +1,10 @@
-use std::{net::SocketAddr, str::FromStr};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
 use anyhow::Result;
+use pea2pea::Config as NodeConfig;
 use tokio::time::{interval, sleep, Duration};
 use ziggurat_zcash::{
     protocol::{
@@ -36,6 +40,11 @@ impl SynthNodeAction for Action {
     fn config(&self) -> ActionCfg {
         ActionCfg {
             msg_filter: MessageFilter::with_all_auto_reply().with_getaddr_filter(Filter::Disabled),
+            network_cfg: NodeConfig {
+                listener_ip: Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+                desired_listening_port: Some(8233),
+                ..Default::default()
+            },
         }
     }
 

--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -1,6 +1,7 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use anyhow::Result;
+use pea2pea::Config as NodeConfig;
 use ziggurat_zcash::tools::{message_filter::MessageFilter, synthetic_node::SyntheticNode};
 
 mod advanced_sn_for_s001;
@@ -32,24 +33,23 @@ trait SynthNodeAction {
 #[allow(dead_code)]
 pub enum ActionType {
     SendGetAddrAndForeverSleep,
-    // TODO(Rqnsom): Add support for choosing listening address in config and apply it in the main.rs here. Details:
-    // To use this Action, use:
-    //    listener_ip: Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
-    //    desired_listening_port: Some(8233),
-    // on lines here:
-    // https://github.com/runziggurat/zcash/blob/8c0985a87a19d2f3c9cfb10b5d3137e144a27928/src/tools/synthetic_node.rs#L149
     AdvancedSnForS001,
 }
 
 /// Action configuration options.
 pub struct ActionCfg {
     pub msg_filter: MessageFilter,
+    pub network_cfg: NodeConfig,
 }
 
 impl Default for ActionCfg {
     fn default() -> Self {
         Self {
             msg_filter: MessageFilter::with_all_auto_reply(),
+            network_cfg: NodeConfig {
+                listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+                ..Default::default()
+            },
         }
     }
 }

--- a/synth_node_bin/src/main.rs
+++ b/synth_node_bin/src/main.rs
@@ -80,6 +80,7 @@ async fn run_synth_node(node_addr: SocketAddr) -> Result<()> {
 
     // Create a synthetic node and enable handshaking.
     let mut synth_node = SyntheticNode::builder()
+        .with_network_config(action.cfg.network_cfg.clone())
         .with_full_handshake()
         .with_message_filter(action.cfg.msg_filter.clone())
         .build()


### PR DESCRIPTION
Introducing an option to configure NodeConfig while setting up the synth node with a SynthNodeBuilder.
So that a user could choose a listening address for a synth node implementation.

Now the AdvancedSnForS001 is fully ready to be used.
Two commits:
```
    feat(synth_node_bin): add network cfg to ActionCfg
```
```
    feat(synth_node): support for flexible network config
```