### PR TITLE
feat(synth_node_bin): new action for quick connect/disconnect

### DIFF
--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -5,6 +5,7 @@ use pea2pea::Config as NodeConfig;
 use ziggurat_zcash::tools::{message_filter::MessageFilter, synthetic_node::SyntheticNode};
 
 mod advanced_sn_for_s001;
+mod quick_connect_and_then_clean_disconnect;
 mod send_get_addr_and_forever_sleep;
 
 /// Defines properties of any action for a synth node binary.
@@ -34,6 +35,7 @@ trait SynthNodeAction {
 pub enum ActionType {
     SendGetAddrAndForeverSleep,
     AdvancedSnForS001,
+    QuickConnectAndThenCleanDisconnect,
 }
 
 /// Action configuration options.
@@ -69,6 +71,9 @@ impl ActionHandler {
         let action = match action_type {
             ActionType::SendGetAddrAndForeverSleep => send_get_addr_and_forever_sleep::action(),
             ActionType::AdvancedSnForS001 => advanced_sn_for_s001::action(),
+            ActionType::QuickConnectAndThenCleanDisconnect => {
+                quick_connect_and_then_clean_disconnect::action()
+            }
         };
         let cfg = action.config();
 

--- a/synth_node_bin/src/action/quick_connect_and_then_clean_disconnect.rs
+++ b/synth_node_bin/src/action/quick_connect_and_then_clean_disconnect.rs
@@ -1,0 +1,34 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use ziggurat_zcash::tools::synthetic_node::SyntheticNode;
+
+use super::{ActionCfg, SynthNodeAction};
+
+pub(super) struct Action;
+
+pub(super) fn action() -> Box<dyn SynthNodeAction> {
+    Box::new(Action {})
+}
+
+#[async_trait::async_trait]
+impl SynthNodeAction for Action {
+    fn info(&self) -> &str {
+        "a synth node which only connects and immediately disconnects properly"
+    }
+
+    fn config(&self) -> ActionCfg {
+        ActionCfg::default()
+    }
+
+    #[allow(unused_variables)]
+    async fn run(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()> {
+        println!("Synthetic node connected to {addr}!");
+
+        // An optional short sleep.
+        //tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        println!("Synthetic node disconnecting!");
+        Ok(())
+    }
+}


### PR DESCRIPTION
The action quickly connects and then cleanly disconnects.
The word `clean` is used here because one more similar action will be added where we will skip the disconnect API on the synth node side.