### PR TITLE
feat(synth_node_bin): add arg for action selection

### DIFF
--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -1,4 +1,8 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::{
+    fmt::{self, Display},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
 use anyhow::Result;
 use pea2pea::Config as NodeConfig;
@@ -30,12 +34,38 @@ trait SynthNodeAction {
 }
 
 /// List of available actions.
-// TODO: Make a command argument to choose action type.
-#[allow(dead_code)]
+#[derive(Clone, Copy)]
 pub enum ActionType {
     SendGetAddrAndForeverSleep,
     AdvancedSnForS001,
     QuickConnectAndThenCleanDisconnect,
+}
+
+impl Display for ActionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::SendGetAddrAndForeverSleep => "SendGetAddrAndForeverSleep",
+                Self::AdvancedSnForS001 => "AdvancedSnForS001",
+                Self::QuickConnectAndThenCleanDisconnect => "QuickConnectAndThenCleanDisconnect",
+            }
+        )
+    }
+}
+
+impl FromStr for ActionType {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SendGetAddrAndForeverSleep" => Ok(Self::SendGetAddrAndForeverSleep),
+            "AdvancedSnForS001" => Ok(Self::AdvancedSnForS001),
+            "QuickConnectAndThenCleanDisconnect" => Ok(Self::QuickConnectAndThenCleanDisconnect),
+            _ => Err("Invalid action type"),
+        }
+    }
 }
 
 /// Action configuration options.


### PR DESCRIPTION
With this change the action can be chosen during the startup of the process.

New help text output:
```
A synthetic node which can connect to the node and preform some actions independently

Usage: synth_node_bin [OPTIONS]

Options:
  -n, --node-addr <NODE_ADDR>      An address of the node in the <ip>:<port> format
  -s, --stubborn                   Always reconnect in the case the connection fails - synthetic node never dies
  -t, --tracing                    Enable tracing
  -a, --action-type <ACTION_TYPE>  Possible actions: SendGetAddrAndForeverSleep / AdvancedSnForS001 / QuickConnectAndThenCleanDisconnect [default: SendGetAddrAndForeverSleep]
  -h, --help                       Print help
  -V, --version                    Print version
```