### PR TITLE
feat(synth_node_bin): new variant for the connect/disconnect action

### DIFF
--- a/synth_node_bin/src/action/advanced_sn_for_s001.rs
+++ b/synth_node_bin/src/action/advanced_sn_for_s001.rs
@@ -45,6 +45,7 @@ impl SynthNodeAction for Action {
                 desired_listening_port: Some(8233),
                 ..Default::default()
             },
+            allow_proper_shutdown: true,
         }
     }
 

--- a/synth_node_bin/src/action/constantly_ask_for_random_blocks.rs
+++ b/synth_node_bin/src/action/constantly_ask_for_random_blocks.rs
@@ -37,7 +37,6 @@ impl SynthNodeAction for Action {
     async fn run(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()> {
         println!("Synthetic node performs an action.");
 
-        // Custom code goes here, example:
         let mut rng = StdRng::from_entropy();
 
         let jstring = fs::read_to_string("hashes.json").expect("could not open hashes file");

--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -11,6 +11,7 @@ use ziggurat_zcash::tools::{message_filter::MessageFilter, synthetic_node::Synth
 mod advanced_sn_for_s001;
 mod constantly_ask_for_random_blocks;
 mod quick_connect_and_then_clean_disconnect;
+mod quick_connect_with_improper_disconnect;
 mod send_get_addr_and_forever_sleep;
 
 /// Defines properties of any action for a synth node binary.
@@ -40,6 +41,7 @@ pub enum ActionType {
     SendGetAddrAndForeverSleep,
     AdvancedSnForS001,
     QuickConnectAndThenCleanDisconnect,
+    QuickConnectWithImproperDisconnect,
     ConstantlyAskForRandomBlocks,
 }
 
@@ -52,6 +54,7 @@ impl Display for ActionType {
                 Self::SendGetAddrAndForeverSleep => "SendGetAddrAndForeverSleep",
                 Self::AdvancedSnForS001 => "AdvancedSnForS001",
                 Self::QuickConnectAndThenCleanDisconnect => "QuickConnectAndThenCleanDisconnect",
+                Self::QuickConnectWithImproperDisconnect => "QuickConnectWithImproperDisconnect",
                 Self::ConstantlyAskForRandomBlocks => "ConstantlyAskForRandomBlocks",
             }
         )
@@ -66,6 +69,7 @@ impl FromStr for ActionType {
             "SendGetAddrAndForeverSleep" => Ok(Self::SendGetAddrAndForeverSleep),
             "AdvancedSnForS001" => Ok(Self::AdvancedSnForS001),
             "QuickConnectAndThenCleanDisconnect" => Ok(Self::QuickConnectAndThenCleanDisconnect),
+            "QuickConnectWithImproperDisconnect" => Ok(Self::QuickConnectWithImproperDisconnect),
             "ConstantlyAskForRandomBlocks" => Ok(Self::ConstantlyAskForRandomBlocks),
             _ => Err("Invalid action type"),
         }
@@ -114,6 +118,9 @@ impl ActionHandler {
             ActionType::AdvancedSnForS001 => advanced_sn_for_s001::action(),
             ActionType::QuickConnectAndThenCleanDisconnect => {
                 quick_connect_and_then_clean_disconnect::action()
+            }
+            ActionType::QuickConnectWithImproperDisconnect => {
+                quick_connect_with_improper_disconnect::action()
             }
             ActionType::ConstantlyAskForRandomBlocks => constantly_ask_for_random_blocks::action(),
         };

--- a/synth_node_bin/src/action/mod.rs
+++ b/synth_node_bin/src/action/mod.rs
@@ -74,8 +74,14 @@ impl FromStr for ActionType {
 
 /// Action configuration options.
 pub struct ActionCfg {
+    /// A message filter for a synthetic node.
     pub msg_filter: MessageFilter,
+
+    /// Network configuration.
     pub network_cfg: NodeConfig,
+
+    /// When enabled, the shutdown API in synthetic node is skipped.
+    pub allow_proper_shutdown: bool,
 }
 
 impl Default for ActionCfg {
@@ -86,6 +92,7 @@ impl Default for ActionCfg {
                 listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                 ..Default::default()
             },
+            allow_proper_shutdown: true,
         }
     }
 }

--- a/synth_node_bin/src/action/quick_connect_with_improper_disconnect.rs
+++ b/synth_node_bin/src/action/quick_connect_with_improper_disconnect.rs
@@ -1,0 +1,37 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use ziggurat_zcash::tools::synthetic_node::SyntheticNode;
+
+use super::{ActionCfg, SynthNodeAction};
+
+pub(super) struct Action;
+
+pub(super) fn action() -> Box<dyn SynthNodeAction> {
+    Box::new(Action {})
+}
+
+#[async_trait::async_trait]
+impl SynthNodeAction for Action {
+    fn info(&self) -> &str {
+        "a synth node which only connects and immediately disconnects improperly"
+    }
+
+    fn config(&self) -> ActionCfg {
+        ActionCfg {
+            allow_proper_shutdown: false,
+            ..Default::default()
+        }
+    }
+
+    #[allow(unused_variables)]
+    async fn run(&self, synth_node: &mut SyntheticNode, addr: SocketAddr) -> Result<()> {
+        println!("Synthetic node connected to {addr}!");
+
+        // An optional short sleep.
+        //tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        println!("Synthetic node disconnecting!");
+        Ok(())
+    }
+}

--- a/synth_node_bin/src/main.rs
+++ b/synth_node_bin/src/main.rs
@@ -89,8 +89,10 @@ async fn run_synth_node(node_addr: SocketAddr, action_type: ActionType) -> Resul
     // Run the wanted action with the node.
     action.execute(&mut synth_node, node_addr).await?;
 
-    // Stop the synthetic node.
-    synth_node.shut_down().await;
+    if action.cfg.allow_proper_shutdown {
+        // Stop the synthetic node.
+        synth_node.shut_down().await;
+    }
 
     Ok(())
 }

--- a/synth_node_bin/src/main.rs
+++ b/synth_node_bin/src/main.rs
@@ -28,7 +28,8 @@ struct CmdArgs {
     tracing: bool,
 
     /// Possible actions:
-    /// SendGetAddrAndForeverSleep / AdvancedSnForS001 / QuickConnectAndThenCleanDisconnect
+    /// SendGetAddrAndForeverSleep / AdvancedSnForS001 / QuickConnectAndThenCleanDisconnect /
+    /// QuickConnectWithImproperDisconnect / ConstantlyAskForRandomBlocks
     #[arg(short = 'a', long, default_value_t = SendGetAddrAndForeverSleep)]
     action_type: ActionType,
 }


### PR DESCRIPTION
This new action is pretty similar to the existing one, but in this case, the socket is not closed properly.

commits:
```
    feat(synth_node_bin): new variant of connect/disconnect action

    The action quickly connects and then disconnects without closing the
    socket properly.
```
```
    feat(synth_node_bin): action cfg allow_shutdown option
```