### PR TITLE
feat(synth_node_bin): add a wrapper debug script

### DIFF
--- a/synth_node_bin/scripts/run_sn.sh
+++ b/synth_node_bin/scripts/run_sn.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# A quick and a simple script to be used for any debugging or testing.
+
+NUM_NODES=$1
+ADDR=$2
+ACTION=$3
+
+## Possible actions:
+# SendGetAddrAndForeverSleep / AdvancedSnForS001 / QuickConnectAndThenCleanDisconnect /
+# QuickConnectWithImproperDisconnect / ConstantlyAskForRandomBlocks
+
+TRACE_LOG=info
+BIN=../target/debug/synth_node_bin
+
+for i in $(seq 1 $NUM_NODES);
+do
+    RUST_LOG=$TRACE_LOG $BIN -t -s -n $ADDR  -a $ACTION &
+done


### PR DESCRIPTION
A simple script for deploying multiple synth_node_bin.
It is nothing official, so it's not very well documented - since it's for our internal usage.

Lots of things are hardcoded in the script, but it can be easily modified on the fly.
It's like a simple template.