### PR TITLE
Update protocol version to 170150

### DIFF
--- a/src/protocol/message/constants.rs
+++ b/src/protocol/message/constants.rs
@@ -12,7 +12,7 @@ pub const HEADER_LEN: usize = 24;
 pub const MAX_MESSAGE_LEN: usize = 2 * 1024 * 1024;
 
 /// The current network protocol version number.
-pub const PROTOCOL_VERSION: u32 = 170_140;
+pub const PROTOCOL_VERSION: u32 = 170_150;
 /// The current network version identifier.
 pub const MAGIC_TESTNET: [u8; MAGIC_LEN] = [0xfa, 0x1a, 0xf9, 0xbf];
 pub const MAGIC_MAINNET: [u8; MAGIC_LEN] = [0x24, 0xe9, 0x27, 0x64];


### PR DESCRIPTION
From 

https://zfnd.org/zebra-4-5-3-and-5-0-0-emergency-soft-fork-and-nu6-2-activation/


Activate the NU6.2 network upgrade (consensus branch ID 0x5437f330) at height 3,364,600 on Mainnet and 4,052,000 on Testnet. NU6.2 re-enables Orchard actions with the fixed Orchard Action circuit and routes Orchard proofs to a per-circuit verifying key (InsecurePreNu6_2 / FixedPostNu6_2). Advertise network protocol version 170150 for NU6.2 on Mainnet, Testnet, and Regtest.