### PR TITLE
Update protocol version from 170150 to 170160

### DIFF
--- a/src/protocol/message/constants.rs
+++ b/src/protocol/message/constants.rs
@@ -12,7 +12,7 @@ pub const HEADER_LEN: usize = 24;
 pub const MAX_MESSAGE_LEN: usize = 2 * 1024 * 1024;
 
 /// The current network protocol version number.
-pub const PROTOCOL_VERSION: u32 = 170_150;
+pub const PROTOCOL_VERSION: u32 = 170_160;
 /// The current network version identifier.
 pub const MAGIC_TESTNET: [u8; MAGIC_LEN] = [0xfa, 0x1a, 0xf9, 0xbf];
 pub const MAGIC_MAINNET: [u8; MAGIC_LEN] = [0x24, 0xe9, 0x27, 0x64];


### PR DESCRIPTION
NU6.3
Activation Height | 3,428,143
Expected Date | ~2026-07-28
Consensus Branch ID | 0x37a5165b
Testnet Activation | Block 4,134,000 (active since v6.0.0-rc.0)

And the protocol version 170160. I double-checked with an engineer, I'll try to find the spec that declares it.